### PR TITLE
Enable cross compile for RPi3 build

### DIFF
--- a/patches/bcm43438/7_45_41_26/nexmon/Makefile
+++ b/patches/bcm43438/7_45_41_26/nexmon/Makefile
@@ -27,11 +27,11 @@ init: FORCE
 	$(Q)mkdir -p obj gen log
 
 brcmfmac.ko: check-nexmon-setup-env
-ifeq ($(shell uname -m),armv7l)
 	@printf "\033[0;31m  BUILDING DRIVER \033[0m brcmfmac/brcmfmac.ko (details: log/driver.log)\n" $@
+ifeq ($(shell uname -m),armv7l)
 	$(Q)make -C /lib/modules/$(shell uname -r)/build M=$$PWD/brcmfmac -j2 >log/driver.log
 else
-	$(warning Warning: Driver can not be compiled on this platform, execute the make command on a raspberry pi)
+	$(Q)make -C $(RPI3_KERNEL_PATH) M=$$PWD/brcmfmac -j2 >log/driver.log
 endif
 
 obj/%.o: src/%.c
@@ -120,6 +120,11 @@ check-nexmon-setup-env:
 ifndef NEXMON_SETUP_ENV
 	$(error run 'source setup_env.sh' first in the repository\'s root directory)
 endif
+ifneq ($(shell uname -m),armv7l)
+ifndef RPI3_KERNEL_PATH
+	$(error RPI3_KERNEL_PATH is undefined. Clone, compile, and set kernel path before compiling Nexmon patches.)
+endif
+endif
 
 backup-firmware:
 ifeq ($(shell uname -m),armv7l)
@@ -144,9 +149,11 @@ clean-firmware: FORCE
 	$(Q)rm -fr $(RAM_FILE) obj gen log src/ucode_compressed.c ucode_compressed.bin
 
 clean: clean-firmware
-ifeq ($(shell uname -m),armv7l)
 	@printf "\033[0;31m  CLEANING DRIVER\033[0m\n" $@
+ifeq ($(shell uname -m),armv7l)
 	$(Q)make -C /lib/modules/$(shell uname -r)/build M=$$PWD/brcmfmac clean
+else
+	$(Q)make -C $(RPI3_KERNEL_PATH) M=$$PWD/brcmfmac clean
 endif
 
 FORCE:


### PR DESCRIPTION
### Prerequisites
- CROSS_COMPILE is set to the path for arm-linux-gnueabihf- binaries
- RPI3_KERNEL_PATH is set to the path of a raspberry pi kernel
- The kernel has already been compiled

### Example
https://github.com/aagallag/kali-arm-build-scripts/commit/094b4b5be7db09eba35d4e29cd10d13836424159