### PR TITLE
Quote adb shell commands in utility Makefiles

### DIFF
--- a/utilities/aircrack-ng/Makefile
+++ b/utilities/aircrack-ng/Makefile
@@ -19,9 +19,9 @@ libs/armeabi/aircrack-ng: Android.mk ../libsqlite/local/armeabi/libsqlite.a ../l
 
 install: libs/armeabi/aircrack-ng
 	adb push libs/armeabi/aireplay-ng /sdcard/
-	adb shell su -c "mount -o remount,rw /system"
-	adb shell su -c "cp /sdcard/aireplay-ng /system/bin/aireplay-ng"
-	
+	adb shell 'su -c "mount -o remount,rw /system"'
+	adb shell 'su -c "cp /sdcard/aireplay-ng /system/bin/aireplay-ng"'
+
 FORCE:
 
 clean:

--- a/utilities/dhdutil/Makefile
+++ b/utilities/dhdutil/Makefile
@@ -5,9 +5,9 @@ libs/armeabi/dhdutil: *.c *.h Android.mk
 
 install: libs/armeabi/dhdutil
 	adb push $< /sdcard/
-	adb shell su -c "mount -o remount,rw /system"
-	adb shell su -c "cp /sdcard/dhdutil /system/bin/dhdutil"
-	adb shell su -c "chmod +x /system/bin/dhdutil"
+	adb shell 'su -c "mount -o remount,rw /system"'
+	adb shell 'su -c "cp /sdcard/dhdutil /system/bin/dhdutil"'
+	adb shell 'su -c "chmod +x /system/bin/dhdutil"'
 
 clean:
 	rm -Rf libs

--- a/utilities/iw/Makefile
+++ b/utilities/iw/Makefile
@@ -5,9 +5,9 @@ libs/armeabi/iw: Android.mk
 
 install: libs/armeabi/iw
 	adb push $< /sdcard/
-	adb shell su -c "mount -o remount,rw /system"
-	adb shell su -c "cp /sdcard/iw /system/bin/iw"
-	adb shell su -c "chmod +x /system/bin/iw"
+	adb shell 'su -c "mount -o remount,rw /system"'
+	adb shell 'su -c "cp /sdcard/iw /system/bin/iw"'
+	adb shell 'su -c "chmod +x /system/bin/iw"'
 
 clean:
 	rm -Rf libs

--- a/utilities/libfakeioctl/Makefile
+++ b/utilities/libfakeioctl/Makefile
@@ -8,12 +8,11 @@ libs/armeabi/libfakeioctl.so: Android.mk fakeioctl.c ../libnexio/local/armeabi/l
 
 install: libs/armeabi/libfakeioctl.so
 	adb push $< /sdcard/
-	adb shell su -c "mount -o remount,rw /system"
-	adb shell su -c "cp /sdcard/libfakeioctl.so /system/lib/libfakeioctl.so"
+	adb shell 'su -c "mount -o remount,rw /system"'
+	adb shell 'su -c "cp /sdcard/libfakeioctl.so /system/lib/libfakeioctl.so"'
 
 clean:
 	rm -Rf libs
 	rm -Rf local
 
 FORCE:
-	

--- a/utilities/netcat/Makefile
+++ b/utilities/netcat/Makefile
@@ -5,9 +5,9 @@ libs/armeabi/nc: netcat.c Android.mk
 
 install: libs/armeabi/nc
 	adb push $< /sdcard/
-	adb shell su -c "mount -o remount,rw /system"
-	adb shell su -c "cp /sdcard/nc /system/bin/nc"
-	adb shell su -c "chmod +x /system/bin/nc"
+	adb shell 'su -c "mount -o remount,rw /system"'
+	adb shell 'su -c "cp /sdcard/nc /system/bin/nc"'
+	adb shell 'su -c "chmod +x /system/bin/nc"'
 
 clean:
 	rm -Rf libs

--- a/utilities/rawproxy/Makefile
+++ b/utilities/rawproxy/Makefile
@@ -16,7 +16,7 @@ clean:
 
 install: libs/armeabi/rawproxy
 	adb push $< /sdcard/
-	adb shell su -c "mount -o remount,rw /system"
-	adb shell su -c "cp /sdcard/rawproxy /system/bin/rawproxy"
+	adb shell 'su -c "mount -o remount,rw /system"'
+	adb shell 'su -c "cp /sdcard/rawproxy /system/bin/rawproxy"'
 
 FORCE:

--- a/utilities/rawproxyreverse/Makefile
+++ b/utilities/rawproxyreverse/Makefile
@@ -16,7 +16,7 @@ clean:
 
 install: libs/armeabi/rawproxyreverse
 	adb push $< /sdcard/
-	adb shell su -c "mount -o remount,rw /system"
-	adb shell su -c "cp /sdcard/rawproxyreverse /system/bin/rawproxyreverse"
+	adb shell 'su -c "mount -o remount,rw /system"'
+	adb shell 'su -c "cp /sdcard/rawproxyreverse /system/bin/rawproxyreverse"'
 
 FORCE:

--- a/utilities/socat/Makefile
+++ b/utilities/socat/Makefile
@@ -5,13 +5,12 @@ libs/armeabi/socat: FORCE
 
 install: libs/armeabi/socat
 	adb push $< /sdcard/
-	adb shell su -c "mount -o remount,rw /system"
-	adb shell su -c "cp /sdcard/socat /system/bin/socat"
-	adb shell su -c "chmod +x /system/bin/socat"
+	adb shell 'su -c "mount -o remount,rw /system"'
+	adb shell 'su -c "cp /sdcard/socat /system/bin/socat"'
+	adb shell 'su -c "chmod +x /system/bin/socat"'
 
 clean:
 	rm -Rf libs
 	rm -Rf local
 
 FORCE:
-	

--- a/utilities/tcpdump/Makefile
+++ b/utilities/tcpdump/Makefile
@@ -14,9 +14,9 @@ libs/armeabi/tcpdump: Android.mk ../libssl/local/armeabi/libssl.a ../libcrypto/l
 
 install: libs/armeabi/tcpdump
 	adb push $< /sdcard/
-	adb shell su -c "mount -o remount,rw /system"
-	adb shell su -c "cp /sdcard/tcpdump /system/bin/tcpdump"
-	adb shell su -c "chmod +x /system/bin/tcpdump"
+	adb shell 'su -c "mount -o remount,rw /system"'
+	adb shell 'su -c "cp /sdcard/tcpdump /system/bin/tcpdump"'
+	adb shell 'su -c "chmod +x /system/bin/tcpdump"'
 
 clean:
 	rm -Rf libs

--- a/utilities/wireless_tools/Makefile
+++ b/utilities/wireless_tools/Makefile
@@ -13,13 +13,13 @@ install: libs/armeabi/iwconfig libs/armeabi/iwlist libs/armeabi/iwpriv
 	adb push libs/armeabi/iwconfig /sdcard/
 	adb push libs/armeabi/iwlist /sdcard/
 	adb push libs/armeabi/iwpriv /sdcard/
-	adb shell su -c "mount -o remount,rw /system"
-	adb shell su -c "cp /sdcard/iwconfig /system/bin/iwconfig"
-	adb shell su -c "cp /sdcard/iwlist /system/bin/iwlist"
-	adb shell su -c "cp /sdcard/iwpriv /system/bin/iwpriv"
-	adb shell su -c "chmod +x /system/bin/iwconfig"
-	adb shell su -c "chmod +x /system/bin/iwlist"
-	adb shell su -c "chmod +x /system/bin/iwpriv"
+	adb shell 'su -c "mount -o remount,rw /system"'
+	adb shell 'su -c "cp /sdcard/iwconfig /system/bin/iwconfig"'
+	adb shell 'su -c "cp /sdcard/iwlist /system/bin/iwlist"'
+	adb shell 'su -c "cp /sdcard/iwpriv /system/bin/iwpriv"'
+	adb shell 'su -c "chmod +x /system/bin/iwconfig"'
+	adb shell 'su -c "chmod +x /system/bin/iwlist"'
+	adb shell 'su -c "chmod +x /system/bin/iwpriv"'
 
 clean:
 	rm -Rf libs


### PR DESCRIPTION
With Android Platform-Tools 23 and higher, the unquoted version would lead to
errors. See also:

https://developer.android.com/studio/command-line/adb.html#shellcommands