### PR TITLE
Changing README for Raspbian8

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ To be able to communicate with the firmware without root priviledges, we created
 * Start a UDP connection for example to activate monitor mode: `nexutil -X<cookie> -m1`
 
 ## Build patches for bcm43438 on the RPI3 using Raspbian 8 (recommended)
-* Make sure the following commands are executed as `root`
+* Make sure the following commands are executed as root: `sudo su`
 * Upgrade your Raspbian installation: `apt-get update && apt-get upgrade`
-* Install the kernel headers to build the driver and some dependencies: `sudo apt install raspberrypi-kernel-headers git libgmp3-dev gawk`
+* Install the kernel headers to build the driver and some dependencies: `sudo apt install raspberrypi-kernel-headers git libgmp3-dev gawk qpdf`
 * Clone our repository: `git clone https://github.com/seemoo-lab/nexmon.git`
 * Go into the root directory of our repository: `cd nexmon`
   * Setup the build environment: `source setup_env.sh`
@@ -88,7 +88,14 @@ To be able to communicate with the firmware without root priviledges, we created
 * In the default setting the brcmfmac driver can be used regularly as a WiFi station with out firmware. To activate monitor mode, execute `nexutil -m2`.
 * At this point the monitor mode is active. There is no need to call *airmon-ng*. 
 * The interface already set the Radiotap header, therefore, tools like *tcpdump* or *airodump-ng* can be used out of the box: `tcpdump -i wlan0`
-* **Note:** It is not possible to connect to an access point anymore using our modified driver and firmware, if you whant to go back to the default behaviour you will need to load the original driver and firmware.
+* *Optional*: To make the RPI3 load the modified driver after reboot:
+  * Find the path of the default driver at reboot: `modinfo brcmfmac` #the first line should be the full path
+  * Backup the original driver: `mv "<PATH TO THE DRIVER>/brcmfmac.ko" "<PATH TO THE DRIVER>/brcmfmac.ko.orig"`
+  * Copy the modified driver: `cp /home/pi/nexmon/patches/bcm43438/7_45_41_26/nexmon/brcmfmac/brcmfmac.ko "<PATH TO THE DRIVER>/"`
+  * Probe all modules and generate new dependency: `depmod -a`
+  * The new driver should be loaded by default after reboot: `reboot`
+  * **Note:** With this setting, you can toggle between Monitor mode and Managed mode with: `nexutil -m2` and `nexutil -m0`
+  * **Note:** It is possible to connect to an access point using our modified driver and firmware, just set the wireless interface in Managed mode.
 
 # How to extract the ROM
 


### PR DESCRIPTION
__Changing README for Raspbian8, Everything stated has been tested with kernel 4.4.50-v7+__
1. Adding `qpdf` dependency, without which 0 byte ucode_compressed.bin is being used, which causes segmentation faults while running nexmon utility.

2. Everything updated in the later section of the README has been tested with kernel  4.4.50-v7+
    a. When the Pi reboots, the default driver is picked by modprobe, which is at the location: `/lib/modules/4.4.50-v7+/kernel/drivers/net/wireless/brcm80211/brcmfmac/brcmfmac.ko` for my kernel version.
    b. This file has to be replaced with the modified driver. And then we need to probe all the modules and build a new dependency file using `depmod -a` (We're backing up the original driver file too)
    c. After reboot, by default, the modified driver will be loaded.

3. With your modified driver, the wireless interface CAN ACTUALLY connect to access points. 
     * `nexutil -m2` and `nexutil -m0` can actually be used to switch between Monitor and Managed modes.
     * I'm using the wpasupplicant to test this.
     * I have collected the output of my experiment:

  ```
root@raspberrypi:/home/pi#
  root@raspberrypi:/home/pi# uname -a
  Linux raspberrypi 4.4.50-v7+ #970 SMP Mon Feb 20 19:18:29 GMT 2017 armv7l GNU/Linux
  root@raspberrypi:/home/pi#
  root@raspberrypi:/home/pi# iwconfig
  wlan0     IEEE 802.11bgn  ESSID:"take it and go"
            Mode:Managed  Frequency:2.437 GHz  Access Point: 10:DA:43:27:C6:A6
            Bit Rate=65 Mb/s   Tx-Power=31 dBm
            Retry short limit:7   RTS thr:off   Fragment thr:off
            Encryption key:off
            Power Management:on
            Link Quality=70/70  Signal level=-14 dBm
            Rx invalid nwid:0  Rx invalid crypt:0  Rx invalid frag:0
            Tx excessive retries:0  Invalid misc:0   Missed beacon:0

  lo        no wireless extensions.

  eth0      no wireless extensions.

  root@raspberrypi:/home/pi#
  root@raspberrypi:/home/pi# nexutil -m2
  root@raspberrypi:/home/pi#
  root@raspberrypi:/home/pi# iwconfig
  wlan0     IEEE 802.11bgn  Mode:Monitor  Tx-Power=31 dBm
            Retry short limit:7   RTS thr:off   Fragment thr:off
            Power Management:on

  lo        no wireless extensions.

  eth0      no wireless extensions.

  root@raspberrypi:/home/pi#
  root@raspberrypi:/home/pi# nexutil -m0
  root@raspberrypi:/home/pi#
  root@raspberrypi:/home/pi# iwconfig
  wlan0     IEEE 802.11bgn  ESSID:"take it and go"
            Mode:Managed  Frequency:2.437 GHz  Access Point: 10:DA:43:27:C6:A6
            Bit Rate=65 Mb/s   Tx-Power=31 dBm
            Retry short limit:7   RTS thr:off   Fragment thr:off
            Encryption key:off
            Power Management:on
            Link Quality=70/70  Signal level=-14 dBm
            Rx invalid nwid:0  Rx invalid crypt:0  Rx invalid frag:0
            Tx excessive retries:0  Invalid misc:0   Missed beacon:0

  lo        no wireless extensions.

  eth0      no wireless extensions.

  root@raspberrypi:/home/pi#
  root@raspberrypi:/home/pi#
```



4. Also, there's another issue, that I have not committed, as I didn't if it would break the operability with nexus devices:
For Raspbian, `nexmon/utilities/nexutil/nexutil.c` file needs to include the header file `#include<types.h>` without which the utility doesn't compile, throughs uint datatype error.