### PR TITLE
bcm4358: new dma functions in wrapper.c and new structs in firmwares/…

### DIFF
--- a/firmwares/bcm4358/structs.common.h
+++ b/firmwares/bcm4358/structs.common.h
@@ -1094,8 +1094,166 @@ struct wlc_bsscfg {
     int PAD;                            /* 0X584 */
 } __attribute__((packed));
 
+/* dma function type
+typedef void (*di_detach_t)(hnddma_t *dmah);
+typedef bool (*di_txreset_t)(hnddma_t *dmah);
+typedef bool (*di_rxreset_t)(hnddma_t *dmah);
+typedef bool (*di_rxidle_t)(hnddma_t *dmah);
+typedef void (*di_txinit_t)(hnddma_t *dmah);
+typedef bool (*di_txenabled_t)(hnddma_t *dmah);
+typedef void (*di_rxinit_t)(hnddma_t *dmah);
+typedef void (*di_txsuspend_t)(hnddma_t *dmah);
+typedef void (*di_txresume_t)(hnddma_t *dmah);
+typedef bool (*di_txsuspended_t)(hnddma_t *dmah);
+typedef bool (*di_txsuspendedidle_t)(hnddma_t *dmah);
+typedef void (*di_txflush_t)(hnddma_t *dmah);
+typedef void (*di_txflush_clear_t)(hnddma_t *dmah);
+typedef int (*di_txfast_t)(hnddma_t *dmah, void *p, bool commit);
+typedef int (*di_txunframed_t)(hnddma_t *dmah, void *p, uint len, bool commit);
+typedef void* (*di_getpos_t)(hnddma_t *di, bool direction);
+typedef void (*di_fifoloopbackenable_t)(hnddma_t *dmah);
+typedef bool  (*di_txstopped_t)(hnddma_t *dmah);
+typedef bool  (*di_rxstopped_t)(hnddma_t *dmah);
+typedef bool  (*di_rxenable_t)(hnddma_t *dmah);
+typedef bool  (*di_rxenabled_t)(hnddma_t *dmah);
+typedef void* (*di_rx_t)(hnddma_t *dmah);
+typedef bool (*di_rxfill_t)(hnddma_t *dmah);
+typedef void (*di_txreclaim_t)(hnddma_t *dmah, txd_range_t range);
+typedef void (*di_rxreclaim_t)(hnddma_t *dmah);
+typedef	uintptr	(*di_getvar_t)(hnddma_t *dmah, const char *name);
+typedef void* (*di_getnexttxp_t)(hnddma_t *dmah, txd_range_t range);
+typedef void* (*di_getnextrxp_t)(hnddma_t *dmah, bool forceall);
+typedef void* (*di_peeknexttxp_t)(hnddma_t *dmah);
+typedef void* (*di_peekntxp_t)(hnddma_t *dmah, int *len, void *txps[], txd_range_t range);
+typedef void* (*di_peeknextrxp_t)(hnddma_t *dmah);
+typedef void (*di_rxparam_get_t)(hnddma_t *dmah, uint16 *rxoffset, uint16 *rxbufsize);
+typedef void (*di_txblock_t)(hnddma_t *dmah);
+typedef void (*di_txunblock_t)(hnddma_t *dmah);
+typedef uint (*di_txactive_t)(hnddma_t *dmah);
+typedef void (*di_txrotate_t)(hnddma_t *dmah);
+typedef void (*di_counterreset_t)(hnddma_t *dmah);
+typedef uint (*di_ctrlflags_t)(hnddma_t *dmah, uint mask, uint flags);
+typedef char* (*di_dump_t)(hnddma_t *dmah, struct bcmstrbuf *b, bool dumpring);
+typedef char* (*di_dumptx_t)(hnddma_t *dmah, struct bcmstrbuf *b, bool dumpring);
+typedef char* (*di_dumprx_t)(hnddma_t *dmah, struct bcmstrbuf *b, bool dumpring);
+typedef uint (*di_rxactive_t)(hnddma_t *dmah);
+typedef uint (*di_txpending_t)(hnddma_t *dmah);
+typedef uint (*di_txcommitted_t)(hnddma_t *dmah);
+typedef int (*di_pktpool_set_t)(hnddma_t *dmah, pktpool_t *pool);
+typedef bool (*di_rxtxerror_t)(hnddma_t *dmah, bool istx);
+typedef void (*di_burstlen_set_t)(hnddma_t *dmah, uint8 rxburstlen, uint8 txburstlen);
+typedef uint (*di_avoidancecnt_t)(hnddma_t *dmah);
+typedef void (*di_param_set_t)(hnddma_t *dmah, uint16 paramid, uint16 paramval);
+typedef bool (*dma_glom_enable_t) (hnddma_t *dmah, uint32 val);
+typedef uint (*dma_active_rxbuf_t) (hnddma_t *dmah);
+
+typedef struct di_fcn_s {
+	di_detach_t		detach;
+	di_txinit_t             txinit;
+	di_txreset_t		txreset;
+	di_txenabled_t          txenabled;
+	di_txsuspend_t          txsuspend;
+	di_txresume_t           txresume;
+	di_txsuspended_t        txsuspended;
+	di_txsuspendedidle_t    txsuspendedidle;
+	di_txflush_t            txflush;
+	di_txflush_clear_t      txflush_clear;
+	di_txfast_t             txfast;
+	di_txunframed_t         txunframed;
+	di_getpos_t             getpos;
+	di_txstopped_t		txstopped;
+	di_txreclaim_t          txreclaim;
+	di_getnexttxp_t         getnexttxp;
+	di_peeknexttxp_t        peeknexttxp;
+	di_peekntxp_t           peekntxp;
+	di_txblock_t            txblock;
+	di_txunblock_t          txunblock;
+	di_txactive_t           txactive;
+	di_txrotate_t           txrotate;
+
+	di_rxinit_t             rxinit;
+	di_rxreset_t            rxreset;
+	di_rxidle_t             rxidle;
+	di_rxstopped_t		rxstopped;
+	di_rxenable_t		rxenable;
+	di_rxenabled_t		rxenabled;
+	di_rx_t                 rx;
+	di_rxfill_t             rxfill;
+	di_rxreclaim_t          rxreclaim;
+	di_getnextrxp_t         getnextrxp;
+	di_peeknextrxp_t        peeknextrxp;
+	di_rxparam_get_t	rxparam_get;
+
+	di_fifoloopbackenable_t fifoloopbackenable;
+	di_getvar_t             d_getvar;
+	di_counterreset_t       counterreset;
+	di_ctrlflags_t          ctrlflags;
+	di_dump_t		dump;
+	di_dumptx_t		dumptx;
+	di_dumprx_t		dumprx;
+	di_rxactive_t		rxactive;
+	di_txpending_t		txpending;
+	di_txcommitted_t	txcommitted;
+	di_pktpool_set_t	pktpool_set;
+	di_rxtxerror_t		rxtxerror;
+	di_burstlen_set_t	burstlen_set;
+	di_avoidancecnt_t	avoidancecnt;
+	di_param_set_t		param_set;
+	dma_glom_enable_t	glom_enab;
+	dma_active_rxbuf_t	dma_activerxbuf;
+	uint			endnum;
+} di_fcn_t;
+
+*/
+/*
+ * DMA Descriptor
+ * Descriptors are only read by the hardware, never written back.
+ */
+typedef volatile struct {
+	uint32	ctrl1;		/* misc control bits */
+	uint32	ctrl2;		/* buffer count and address extension */
+	uint32	addrlow;	/* memory address of the date buffer, bits 31:0 */
+	uint32	addrhigh;	/* memory address of the date buffer, bits 63:32 */
+} dma64dd_t;
+
+/* range param for dma_getnexttxp() and dma_txreclaim */
+typedef enum txd_range {
+	HNDDMA_RANGE_ALL		= 1,
+	HNDDMA_RANGE_TRANSMITTED,
+	HNDDMA_RANGE_TRANSFERED
+} txd_range_t;
+
+struct pktpool;
+typedef void (*pktpool_cb_t)(struct pktpool *pool, void *arg);
+typedef struct {
+	pktpool_cb_t cb;
+	void *arg;
+} pktpool_cbinfo_t;
+
+#define PKTPOOL_LEN_MAX		40
+#define PKTPOOL_CB_MAX		3
+
+typedef struct pktpool {
+	bool inited;
+	uint16 r;
+	uint16 w;
+	uint16 len;
+	uint16 maxlen;
+	uint16 plen;
+	bool istx;
+	bool empty;
+	uint8 cbtoggle;
+	uint8 cbcnt;
+	uint8 ecbcnt;
+	bool emptycb_disable;
+	pktpool_cbinfo_t *availcb_excl;
+	pktpool_cbinfo_t cbs[PKTPOOL_CB_MAX];
+	pktpool_cbinfo_t ecbs[PKTPOOL_CB_MAX];
+	void *q[PKTPOOL_LEN_MAX + 1];
+} pktpool_t;
+
 struct hnddma_pub {
-    void *di_fn;                    /* DMA function pointers */
+    void *di_fn;                    /* DMA function pointers struct di_fcn_s*/
     unsigned int txavail;           /* # free tx descriptors */
     unsigned int dmactrlflags;      /* dma control flags */
     /* rx error counters */
@@ -1110,14 +1268,14 @@ struct dma_info {
     int msg_level;              /* message level pointer */
     int something;
     char name[8];               /* callers name for diag msgs */
-    void *osh;                  
-    void *sih;                  
+    void *osh;
+    void *sih;
     bool dma64;                 /* this dma engine is operating in 64-bit mode */
     bool addrext;               /* this dma engine supports DmaExtendedAddrChanges */
     char gap2[2];
     void *txregs;               /* 64-bit dma tx engine registers */
     void *rxregs;               /* 64-bit dma rx engine registers */
-    void *txd;                  /* pointer to dma64 tx descriptor ring */
+    dma64dd_t *txd;                  /* pointer to dma64 tx descriptor ring */
     void *rxd;                  /* pointer to dma64 rx descriptor ring */
     short dmadesc_align;        /* alignment requirement for dma descriptors */
     short ntxd;                 /* # tx descriptors tunable */
@@ -1125,7 +1283,7 @@ struct dma_info {
     short txout;                /* index of next descriptor to post */
     void **txp;                 /* pointer to parallel array of pointers to packets */
     void *tx_dmah;              /* DMA MAP meta-data handle */
-    int txp_dmah;               
+    int txp_dmah;
     int txdpa;                  /* Aligned physical address of descriptor ring */
     int txdpaorig;              /* Original physical address of descriptor ring */
     short txdalign;             /* #bytes added to alloc'd mem to align txd */
@@ -1406,7 +1564,7 @@ struct d11regs {
     unsigned short PAD;                 /* SPR_PSM_0x6a                     0x4EA */
     unsigned short PAD;                 /* SPR_PSM_0x6c                     0x4EC */
     unsigned short PAD;                 /* SPR_PSM_0x6e                     0x4EE */
-    unsigned short psm_corectlsts;      /* SPR_PSM_0x70                     0x4F0 *//* Corerev >= 13 */  
+    unsigned short psm_corectlsts;      /* SPR_PSM_0x70                     0x4F0 *//* Corerev >= 13 */
     unsigned short PAD;                 /* SPR_PSM_0x72                     0x4F2 */
     unsigned short PAD;                 /* SPR_PSM_0x74                     0x4F4 */
     unsigned short PAD;                 /* SPR_PSM_0x76                     0x4F6 */
@@ -1681,4 +1839,3 @@ struct nexmon_header {
     uint32 args[3];
     uint8 payload[1];
 } __attribute__((packed));
-

--- a/patches/common/wrapper.c
+++ b/patches/common/wrapper.c
@@ -73,18 +73,6 @@ void *
 dma_attach(void *osh, char *name, void* sih, unsigned int dmaregstx, unsigned int dmaregsrx, unsigned int ntxd, unsigned int nrxd, unsigned int rxbufsize, int rxextheadroom, unsigned int nrxpost, unsigned int rxoffset, void *msg_level)
 RETURN_DUMMY
 
-AT(CHIP_VER_BCM4339, FW_VER_ALL, 0x8c69c)
-AT(CHIP_VER_BCM43438, FW_VER_7_45_41_26_r640327, 0x4E44)
-void *
-dma_rx(void *di)
-RETURN_DUMMY
-
-AT(CHIP_VER_BCM4339, FW_VER_ALL, 0x8c6cc)
-AT(CHIP_VER_BCM43438, FW_VER_7_45_41_26_r640327, 0x5070)
-void *
-dma_rxfill(void *di)
-RETURN_DUMMY
-
 AT(CHIP_VER_BCM4339, FW_VER_ALL, 0x8C49C)
 AT(CHIP_VER_BCM43438, FW_VER_7_45_41_26_r640327, 0x3520)
 AT(CHIP_VER_BCM4330, FW_VER_ALL, 0x80B9C8)
@@ -295,6 +283,11 @@ RETURN_DUMMY
 AT(CHIP_VER_BCM4339, FW_VER_ALL, 0x12794)
 int
 sprintf(char *buf, const char *format, ...)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x3818)
+int
+strcmp(char *str1, char *str2)
 RETURN_DUMMY
 
 AT(CHIP_VER_BCM4339, FW_VER_ALL, 0x12824)
@@ -649,6 +642,169 @@ int
 bus_binddev(void *sdio_hw, void *sdiodev, void *d11dev)
 RETURN_DUMMY
 
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x6BD8)
+void *
+dma_active_rxbuf(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x6C0C)
+int
+dma_avoidancecnt(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x6C20)
+struct hnddma_pub *
+dma_counter_reset(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x6C2C)
+int
+dma_ctrlflags(struct hnddma_pub *dmah, int mask, int flags)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x6CE0)
+int
+dma_detach(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x6D38)
+void *
+dma_getnextrxp(struct hnddma_pub *dmah, bool forceall)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x75A8)
+void *
+dma_getnexttxp(struct hnddma_pub *dmah, txd_range_t range)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x7670)
+void *
+dma_getpos(struct hnddma_pub *dmah, bool direction)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x6D48)
+void *
+dma_getvar(struct hnddma_pub *dmah, char* name) //bcm4358: name is either ""&txavail" or "&rxavail"
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x6DAC)
+void *
+dma_param_set(struct hnddma_pub *dmah, uint paramid, char paramval)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x6E14)
+void *
+dma_peeknextrxp(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x6E5C)
+void *
+dma_peeknexttxp(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x6EA0)
+void *
+dma_peekntxp(struct hnddma_pub *dmah, int *len, void *txps[], txd_range_t range)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x6F4C)
+void *
+dma_pktpool_set(struct hnddma_pub *dmah, pktpool_t *pool)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4339, FW_VER_ALL, 0x8c69c)
+AT(CHIP_VER_BCM43438, FW_VER_7_45_41_26_r640327, 0x4E44)
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x6F54)
+void *
+dma_rx(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x7050)
+int
+dma_rxactive(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x7068)
+struct hnddma_pub *
+dma_rxenable(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x76E4)
+int
+dma_rxenabled(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x6D2C)
+struct hnddma_pub *
+dma_rxfifoloopback_enable(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x18B6FC)
+AT(CHIP_VER_BCM4339, FW_VER_ALL, 0x8c6cc)
+void
+dma_rxfill(struct hnddma_pub *dmah)
+VOID_DUMMY
+
+AT(CHIP_VER_BCM43438, FW_VER_7_45_41_26_r640327, 0x5070)
+int
+dma_rxfill_bcm43438(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x76F4)
+bool
+dma_rxidle(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x7268)
+struct hnddma_pub *
+dma_rxinit(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x7040)
+int
+dma_rxparam_get(struct hnddma_pub *dmah, uint16 *rxoffset, uint16 *rxbufsize)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x72FC)
+int
+dma_rxreclaim(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x7714)
+int
+dma_rxreset(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x774C)
+bool
+dma_rxstopped(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x734C)
+int
+dma_rxtxerror(struct hnddma_pub *dmah, bool istx)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x73D0)
+int
+dma_txactive(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x73E8)
+struct hnddma_pub *
+dma_txblock(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x73F0)
+int
+dma_txcommited(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x7760)
+int
+dma_txenabled(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
 AT(CHIP_VER_BCM4339, FW_VER_6_37_32_RC23_34_40_r581243, 0x1844B2)
 AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x7770)
 void *
@@ -658,6 +814,61 @@ RETURN_DUMMY
 AT(CHIP_VER_BCM4339, FW_VER_6_37_32_RC23_34_40_r581243, 0x1844B6)
 void *
 dma_txfast_plus_4(void *di, void *p, int commit)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x7AC4)
+struct hnddma_pub *
+dma_txflush_clear(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x7B00)
+struct hnddma_pub *
+dma_txinit(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x7418)
+int
+dma_txpending(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x7B00)
+struct hnddma_pub *
+dma_txreclaim(struct hnddma_pub *dmah, txd_range_t range)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x7BD8)
+bool
+dma_txreset(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x7C60)
+struct hnddma_pub *
+dma_txresume(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x7C74)
+int
+dma_txrotate(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x7D9C)
+bool
+dma_txstopped(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x7DB0)
+struct hnddma_pub *
+dma_txsuspend(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x7DC4)
+int
+dma_txsuspended(struct hnddma_pub *dmah)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x7DD8)
+int
+dma_txsuspended_idle(struct hnddma_pub *dmah)
 RETURN_DUMMY
 
 AT(CHIP_VER_BCM4339, FW_VER_6_37_32_RC23_34_40_r581243, 0x182750)


### PR DESCRIPTION
…bcm4358/structs.common.h

had to fiddle with dma_rxfill, because on bcm43438 it returns int, while it returns void on other firmwares. -> split it up. Hope that is ok:

AT(CHIP_VER_BCM4358, FW_VER_ALL, 0x18B6FC)
AT(CHIP_VER_BCM4339, FW_VER_ALL, 0x8c6cc)
void
dma_rxfill(struct hnddma_pub *dmah)
VOID_DUMMY

AT(CHIP_VER_BCM43438, FW_VER_7_45_41_26_r640327, 0x5070)
int
dma_rxfill_bcm43438(struct hnddma_pub *dmah)
RETURN_DUMMY

Signed-off-by: Robin Morawetz <robin.morawetz@gmail.com>