### PR TITLE
quote paths to buildtools

### DIFF
--- a/firmwares/bcm4330/5_90_100_41_sta/Makefile
+++ b/firmwares/bcm4330/5_90_100_41_sta/Makefile
@@ -4,12 +4,12 @@ all: ucode.bin flashpatches.c
 
 ucode.bin: $(RAM_FILE) definitions.mk
 	@printf "\033[0;31m  EXTRACTING UCODE\033[0m\n"
-	$(Q)$(NEXMON_ROOT)/buildtools/ucode_extractor/ucodeext -r $< -b $(UCODESTART) -l $(UCODESIZE) -o $@
+	$(Q)"$(NEXMON_ROOT)/buildtools/ucode_extractor/ucodeext" -r $< -b $(UCODESTART) -l $(UCODESIZE) -o $@
 
 flashpatches.c: $(RAM_FILE) definitions.mk
 	@printf "\033[0;31m  EXTRACTING FLASHPATCHES\033[0m\n"
 	$(Q)printf "#include <patcher.h>\n\n" > flashpatches.c
-	$(Q)$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext -r $< -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) >> $@
+	$(Q)"$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext" -r $< -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) >> $@
 
 clean:
 	@printf "\033[0;31m  CLEANING\033[0m\n"

--- a/firmwares/bcm4339/6_37_34_43/Makefile
+++ b/firmwares/bcm4339/6_37_34_43/Makefile
@@ -13,11 +13,11 @@ templateram.bin: $(RAM_FILE) definitions.mk
 flashpatches.c: $(RAM_FILE) definitions.mk
 	@printf "\033[0;31m  EXTRACTING FLASHPATCHES\033[0m\n"
 	$(Q)printf "#include <patcher.h>\n\n" > flashpatches.c
-	$(Q)$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext -r $< -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) >> $@
+	$(Q)"$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext" -r $< -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) >> $@
 
 rom.bin: ../rom.bin
 	@printf "\033[0;31m  APPLYING FLASHPATCHES TO CLEAN ROM\033[0m\n"
-	$(Q)$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext -r $(RAM_FILE) -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) -i $< -o $@ -t $(ROMSTART) > /dev/null
+	$(Q)"$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext" -r $(RAM_FILE) -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) -i $< -o $@ -t $(ROMSTART) > /dev/null
 
 clean:
 	@printf "\033[0;31m  CLEANING\033[0m\n"

--- a/firmwares/bcm43430a1/7_45_41_26/Makefile
+++ b/firmwares/bcm43430a1/7_45_41_26/Makefile
@@ -4,7 +4,7 @@ all: ucode.bin templateram.bin flashpatches.c
 
 ucode.bin: $(RAM_FILE) definitions.mk
 	@printf "\033[0;31m  EXTRACTING UCODE\033[0m\n"
-	$(Q)$(NEXMON_ROOT)/buildtools/ucode_extractor/ucodeext -r $< -b $(UCODESTART) -l $(UCODESIZE) -o $@
+	$(Q)"$(NEXMON_ROOT)/buildtools/ucode_extractor/ucodeext" -r $< -b $(UCODESTART) -l $(UCODESIZE) -o $@
 
 templateram.bin: $(RAM_FILE) definitions.mk
 	@printf "\033[0;31m  EXTRACTING TEMPLATERAM\033[0m\n"
@@ -13,11 +13,11 @@ templateram.bin: $(RAM_FILE) definitions.mk
 flashpatches.c: $(RAM_FILE) definitions.mk
 	@printf "\033[0;31m  EXTRACTING FLASHPATCHES\033[0m\n"
 	$(Q)printf "#include <patcher.h>\n\n" > flashpatches.c
-	$(Q)$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext -r $< -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) >> $@
+	$(Q)"$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext" -r $< -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) >> $@
 
 rom.bin: ../rom.bin
 	@printf "\033[0;31m  APPLYING FLASHPATCHES TO CLEAN ROM\033[0m\n"
-	$(Q)$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext -r $(RAM_FILE) -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) -i $< -o $@ -t $(ROMSTART) > /dev/null
+	$(Q)"$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext" -r $(RAM_FILE) -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) -i $< -o $@ -t $(ROMSTART) > /dev/null
 
 complete.bin: brcmfmac43430-sdio.bin rom.bin
 	@printf "\033[0;31m  CONCATENATING RAM AND ROM\033[0m\n"

--- a/firmwares/bcm43430a1/7_45_41_46/Makefile
+++ b/firmwares/bcm43430a1/7_45_41_46/Makefile
@@ -4,7 +4,7 @@ all: ucode.bin templateram.bin flashpatches.c
 
 ucode.bin: $(RAM_FILE) definitions.mk
 	@printf "\033[0;31m  EXTRACTING UCODE\033[0m\n"
-	$(Q)$(NEXMON_ROOT)/buildtools/ucode_extractor/ucodeext -r $< -b $(UCODESTART) -l $(UCODESIZE) -o $@
+	$(Q)"$(NEXMON_ROOT)/buildtools/ucode_extractor/ucodeext" -r $< -b $(UCODESTART) -l $(UCODESIZE) -o $@
 
 templateram.bin: $(RAM_FILE) definitions.mk
 	@printf "\033[0;31m  EXTRACTING TEMPLATERAM\033[0m\n"
@@ -13,11 +13,11 @@ templateram.bin: $(RAM_FILE) definitions.mk
 flashpatches.c: $(RAM_FILE) definitions.mk
 	@printf "\033[0;31m  EXTRACTING FLASHPATCHES\033[0m\n"
 	$(Q)printf "#include <patcher.h>\n\n" > flashpatches.c
-	$(Q)$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext -r $< -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) >> $@
+	$(Q)"$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext" -r $< -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) >> $@
 
 rom.bin: ../rom.bin
 	@printf "\033[0;31m  APPLYING FLASHPATCHES TO CLEAN ROM\033[0m\n"
-	$(Q)$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext -r $(RAM_FILE) -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) -i $< -o $@ -t $(ROMSTART) > /dev/null
+	$(Q)"$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext" -r $(RAM_FILE) -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) -i $< -o $@ -t $(ROMSTART) > /dev/null
 
 complete.bin: brcmfmac43430-sdio.bin rom.bin
 	@printf "\033[0;31m  CONCATENATING RAM AND ROM\033[0m\n"

--- a/firmwares/bcm43438/7_45_41_26/Makefile
+++ b/firmwares/bcm43438/7_45_41_26/Makefile
@@ -4,7 +4,7 @@ all: ucode.bin templateram.bin flashpatches.c
 
 ucode.bin: $(RAM_FILE) definitions.mk
 	@printf "\033[0;31m  EXTRACTING UCODE\033[0m\n"
-	$(Q)$(NEXMON_ROOT)/buildtools/ucode_extractor/ucodeext -r $< -b $(UCODESTART) -l $(UCODESIZE) -o $@
+	$(Q)"$(NEXMON_ROOT)/buildtools/ucode_extractor/ucodeext" -r $< -b $(UCODESTART) -l $(UCODESIZE) -o $@
 
 templateram.bin: $(RAM_FILE) definitions.mk
 	@printf "\033[0;31m  EXTRACTING TEMPLATERAM\033[0m\n"
@@ -13,7 +13,7 @@ templateram.bin: $(RAM_FILE) definitions.mk
 flashpatches.c: $(RAM_FILE) definitions.mk
 	@printf "\033[0;31m  EXTRACTING FLASHPATCHES\033[0m\n"
 	$(Q)printf "#include <patcher.h>\n\n" > flashpatches.c
-	$(Q)$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext -r $< -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) >> $@
+	$(Q)"$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext" -r $< -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) >> $@
 
 clean:
 	@printf "\033[0;31m  CLEANING\033[0m\n"

--- a/firmwares/bcm4356/7_35_101_5_sta/Makefile
+++ b/firmwares/bcm4356/7_35_101_5_sta/Makefile
@@ -13,11 +13,11 @@ templateram.bin: $(RAM_FILE) definitions.mk
 flashpatches.c: $(RAM_FILE) definitions.mk
 	@printf "\033[0;31m  EXTRACTING FLASHPATCHES\033[0m\n"
 	$(Q)printf "#include <patcher.h>\n\n" > flashpatches.c
-	$(Q)$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext -r $< -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) >> $@
+	$(Q)"$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext" -r $< -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) >> $@
 
 rom.bin: ../rom.bin
 	@printf "\033[0;31m  APPLYING FLASHPATCHES TO CLEAN ROM\033[0m\n"
-	$(Q)$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext -r $(RAM_FILE) -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) -i $< -o $@ -t $(ROMSTART) > /dev/null
+	$(Q)"$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext" -r $(RAM_FILE) -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) -i $< -o $@ -t $(ROMSTART) > /dev/null
 
 clean:
 	@printf "\033[0;31m  CLEANING\033[0m\n"

--- a/firmwares/bcm4358/7_112_200_17_sta/Makefile
+++ b/firmwares/bcm4358/7_112_200_17_sta/Makefile
@@ -13,11 +13,11 @@ templateram.bin: $(RAM_FILE) definitions.mk
 flashpatches.c: $(RAM_FILE) definitions.mk
 	@printf "\033[0;31m  EXTRACTING FLASHPATCHES\033[0m\n"
 	$(Q)printf "#include <patcher.h>\n\n" > flashpatches.c
-	$(Q)$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext -r $< -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) >> $@
+	$(Q)"$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext" -r $< -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) >> $@
 
 rom.bin: ../rom.bin
 	@printf "\033[0;31m  APPLYING FLASHPATCHES TO CLEAN ROM\033[0m\n"
-	$(Q)$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext -r $(RAM_FILE) -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) -i $< -o $@ -t $(ROMSTART) > /dev/null
+	$(Q)"$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext" -r $(RAM_FILE) -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) -i $< -o $@ -t $(ROMSTART) > /dev/null
 
 clean:
 	@printf "\033[0;31m  CLEANING\033[0m\n"

--- a/firmwares/bcm4358/7_112_201_3_sta/Makefile
+++ b/firmwares/bcm4358/7_112_201_3_sta/Makefile
@@ -13,11 +13,11 @@ templateram.bin: $(RAM_FILE) definitions.mk
 flashpatches.c: $(RAM_FILE) definitions.mk
 	@printf "\033[0;31m  EXTRACTING FLASHPATCHES\033[0m\n"
 	$(Q)printf "#include <patcher.h>\n\n" > flashpatches.c
-	$(Q)$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext -r $< -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) >> $@
+	$(Q)"$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext" -r $< -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) >> $@
 
 rom.bin: ../rom.bin
 	@printf "\033[0;31m  APPLYING FLASHPATCHES TO CLEAN ROM\033[0m\n"
-	$(Q)$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext -r $(RAM_FILE) -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) -i $< -o $@ -t $(ROMSTART) > /dev/null
+	$(Q)"$(NEXMON_ROOT)/buildtools/flash_patch_extractor/fpext" -r $(RAM_FILE) -s $(RAMSTART) -b $(FP_CONFIG_ORIGBASE) -e $(FP_CONFIG_ORIGEND) -i $< -o $@ -t $(ROMSTART) > /dev/null
 
 clean:
 	@printf "\033[0;31m  CLEANING\033[0m\n"


### PR DESCRIPTION
Without quotes, if the NEXMON_ROOT path has any spaces, `make` does not interpret them properly and the build fails.