### PR TITLE
Fix btnInstallNexmonFirmware text

### DIFF
--- a/app/app/src/main/res/layout/fragment_nexmon.xml
+++ b/app/app/src/main/res/layout/fragment_nexmon.xml
@@ -199,7 +199,7 @@
                     android:id="@+id/btnInstallNexmonFirmware"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="Install Nexmon Firmware" />
+                    android:text="Install Selected Firmware" />
 
 
 


### PR DESCRIPTION
Hi,

First of all,  thanks for the great project and app!

I think that you can improve a bit the app layout of the Firmware installation view. This is just a small fix, however you can easily improve the backup and restore text and logic. In my understanding the backup is created even if there is already a backup file and a new backup file is create with a`.bac` appended. Additionally, it is not clear from the screen which backup is restored when there are multiple backups. What I did to restore the old firmware was to manually select it and click the Install Nexmon Firmware.