### PR TITLE
Turn on crash dumps by default on 7.45.189

### DIFF
--- a/patches/bcm43455c0/7_45_189/nexmon/brcmfmac_4.14.y-nexmon/sdio.c
+++ b/patches/bcm43455c0/7_45_189/nexmon/brcmfmac_4.14.y-nexmon/sdio.c
@@ -1103,6 +1103,8 @@ static void brcmf_sdio_get_console_addr(struct brcmf_sdio *bus)
 }
 #endif /* DEBUG */
 
+static int brcmf_sdio_readconsole(struct brcmf_sdio *bus);
+
 static u32 brcmf_sdio_hostmail(struct brcmf_sdio *bus)
 {
 	u32 intstatus = 0;
@@ -1178,9 +1180,11 @@ static u32 brcmf_sdio_hostmail(struct brcmf_sdio *bus)
 			 HMB_DATA_NAKHANDLED |
 			 HMB_DATA_FC |
 			 HMB_DATA_FWREADY |
-			 HMB_DATA_FCDATA_MASK | HMB_DATA_VERSION_MASK))
+			 HMB_DATA_FCDATA_MASK | HMB_DATA_VERSION_MASK)) {
 		brcmf_err("Unknown mailbox data content: 0x%02x\n",
 			  hmb_data);
+		brcmf_sdio_readconsole(bus);
+			 }
 
 	return intstatus;
 }

--- a/patches/bcm43455c0/7_45_189/nexmon/brcmfmac_4.19.y-nexmon/sdio.c
+++ b/patches/bcm43455c0/7_45_189/nexmon/brcmfmac_4.19.y-nexmon/sdio.c
@@ -1049,6 +1049,8 @@ static void brcmf_sdio_get_console_addr(struct brcmf_sdio *bus)
 }
 #endif /* DEBUG */
 
+static int brcmf_sdio_readconsole(struct brcmf_sdio *bus);
+
 static u32 brcmf_sdio_hostmail(struct brcmf_sdio *bus)
 {
 	struct brcmf_sdio_dev *sdiod = bus->sdiodev;
@@ -1075,6 +1077,7 @@ static u32 brcmf_sdio_hostmail(struct brcmf_sdio *bus)
 	if (hmb_data & HMB_DATA_FWHALT) {
 		brcmf_err("mailbox indicates firmware halted\n");
 		brcmf_dev_coredump(&sdiod->func1->dev);
+		brcmf_sdio_readconsole(bus);
 	}
 
 	/* Dongle recomposed rx frames, accept them again */

--- a/patches/bcm43455c0/7_45_189/nexmon/src/console.c
+++ b/patches/bcm43455c0/7_45_189/nexmon/src/console.c
@@ -58,3 +58,6 @@ patch_console_size_2(void)
 {
 	asm("mov r2, 0x800\n");
 }
+
+__attribute__((at(0x19AB20, "", CHIP_VER_BCM43455c0, FW_VER_7_45_189)))
+BPatch(do_not_print_full_stack, 0x19AB58);


### PR DESCRIPTION
Hi,
I thought that it could be useful to have crash dumps turned on by default on 7.45.189 (bcm43455c0), at least until stability issues are definitely solved.
I modified brcmfmac 4.14/19 to print internal console to kernel log when a halt is detected and added a patch to print only the first 32 bytes of stack instead of the full dump (to prevent registers dump being overwritten)