### PR TITLE
Added `reboot` instruction to RPi section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ To be able to communicate with the firmware without root priviledges, we created
   * `cd buildtools/isl-0.10`, `./configure`, `make`, `make install`, `ln -s /usr/local/lib/libisl.so /usr/lib/arm-linux-gnueabihf/libisl.so.10`
 * Check if `/usr/lib/arm-linux-gnueabihf/libmpfr.so.4` exists, if not, compile it from source:
   * `cd buildtools/mpfr-3.1.4`, `./configure`, `make`, `make install`, `ln -s /usr/local/lib/libmpfr.so /usr/lib/arm-linux-gnueabihf/libmpfr.so.4`
+* Reboot: `sudo reboot`
 * Then you can setup the build environment for compiling firmware patches
   * Setup the build environment: `source setup_env.sh`
   * Compile some build tools and extract the ucode and flashpatches from the original firmware files: `make`


### PR DESCRIPTION
If you don't reboot at some point after `apt-get {update,upgrade}` then the Makefiles in `patches/...` will incorrectly look for the pre-upgrade modules (`4.19.57-v7+` on a fresh NOOBS build), rather than the upgraded ones -- as of right now, that would be `4.19.66-v7+`

```
Linux raspberrypi 4.19.57-v7+ #1244 SMP Thu Jul 4 18:45:25 BST 2019 armv7l GNU/Linux
pi@raspberrypi:~/nexmon $ popd
~/nexmon/patches/bcm43455c0/7_45_154/nexmon
pi@raspberrypi:~/nexmon/patches/bcm43455c0/7_45_154/nexmon $ make

[...]

  APPLYING PATCHES gen/nexmon.mk => brcmfmac43455-sdio.bin (details: log/patches.log)
  BUILDING DRIVER for kernel 4.19 brcmfmac_4.19.y-nexmon/brcmfmac.ko (details: log/driver.log)
make[1]: *** /lib/modules/4.19.57-v7+/build: No such file or directory.  Stop.
make: *** [Makefile:52: brcmfmac.ko] Error 2

pi@raspberrypi:~/nexmon/patches/bcm43455c0/7_45_154/nexmon $ ls /lib/modules/
4.19.66+  4.19.66-v7+  4.19.66-v7l+
```
