### PR TITLE
Make aircrack-ng build for arm64-v8a

### DIFF
--- a/utilities/aircrack-ng/Android.mk
+++ b/utilities/aircrack-ng/Android.mk
@@ -34,28 +34,28 @@ MY_CFLAGS		:= -g -W -Wall -O3 -DANDROID -D_REVISION=0 -D_FILE_OFFSET_BITS=64 \
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := libssl
-LOCAL_SRC_FILES := $(LOCAL_PATH)/../libssl/local/armeabi/libssl.a
+LOCAL_SRC_FILES := $(LOCAL_PATH)/../libssl/local/$(TARGET_ARCH_ABI)/libssl.a
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/../boringssl/src/include
 include $(PREBUILT_STATIC_LIBRARY)
 
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := libcrypto
-LOCAL_SRC_FILES := $(LOCAL_PATH)/../libcrypto/local/armeabi/libcrypto.a
+LOCAL_SRC_FILES := $(LOCAL_PATH)/../libcrypto/local/$(TARGET_ARCH_ABI)/libcrypto.a
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/../boringssl/src/include
 include $(PREBUILT_STATIC_LIBRARY)
 
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := libsqlite
-LOCAL_SRC_FILES := $(LOCAL_PATH)/../libsqlite/local/armeabi/libsqlite.a
+LOCAL_SRC_FILES := $(LOCAL_PATH)/../libsqlite/local/$(TARGET_ARCH_ABI)/libsqlite.a
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/../libsqlite
 include $(PREBUILT_STATIC_LIBRARY)
 
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := libosdep
-LOCAL_SRC_FILES := $(LOCAL_PATH)/../libosdep/local/armeabi/libosdep.a
+LOCAL_SRC_FILES := $(LOCAL_PATH)/../libosdep/local/$(TARGET_ARCH_ABI)/libosdep.a
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/../libosdep/src
 include $(PREBUILT_STATIC_LIBRARY)
 
@@ -63,7 +63,12 @@ include $(PREBUILT_STATIC_LIBRARY)
 include $(CLEAR_VARS)
 LOCAL_MODULE		:= aircrack-ng
 LOCAL_SRC_FILES		:= $(MY_OBJS_AC)
-LOCAL_CFLAGS		+= $(MY_CFLAGS) -mfloat-abi=softfp -mfpu=neon -march=armv7 -DSIMD_CORE
+ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
+    LOCAL_CFLAGS		+= $(MY_CFLAGS) -march=armv8-a+fp+crc+crypto+simd -mcpu=cortex-a53
+    LOCAL_CFLAGS		+= -DSIMD_CORE -DSIMD_COEF_64 -D__ARM_NEON__
+else
+    LOCAL_CFLAGS		+= $(MY_CFLAGS) -mfloat-abi=softfp -mfpu=neon -march=armv7 -DSIMD_CORE
+endif
 LOCAL_STATIC_LIBRARIES  += libcrypto libssl libosdep libsqlite
 LOCAL_LDLIBS		+= -landroid
 include $(BUILD_EXECUTABLE)

--- a/utilities/aircrack-ng/Application.mk
+++ b/utilities/aircrack-ng/Application.mk
@@ -1,3 +1,3 @@
 APP_STL:=stlport_static
 APP_BUILD_SCRIPT := Android.mk
-
+APP_ABI := armeabi arm64-v8a

--- a/utilities/libcrypto/Application.mk
+++ b/utilities/libcrypto/Application.mk
@@ -1,2 +1,2 @@
 APP_BUILD_SCRIPT := Android.mk
-
+APP_ABI := armeabi arm64-v8a

--- a/utilities/libosdep/Application.mk
+++ b/utilities/libosdep/Application.mk
@@ -1,2 +1,2 @@
 APP_BUILD_SCRIPT := Android.mk
-
+APP_ABI := armeabi arm64-v8a

--- a/utilities/libsqlite/Application.mk
+++ b/utilities/libsqlite/Application.mk
@@ -1,2 +1,2 @@
 APP_BUILD_SCRIPT := Android.mk
-
+APP_ABI := armeabi arm64-v8a

--- a/utilities/libssl/Application.mk
+++ b/utilities/libssl/Application.mk
@@ -1,2 +1,2 @@
 APP_BUILD_SCRIPT := Android.mk
-
+APP_ABI := armeabi arm64-v8a


### PR DESCRIPTION
This allows building for armv8-a. Works on Nexus 6p