### PR TITLE
improved plugin & associated makefile for recent target toolchains

### DIFF
--- a/buildtools/gcc-nexmon-plugin/Makefile
+++ b/buildtools/gcc-nexmon-plugin/Makefile
@@ -1,10 +1,23 @@
 all: nexmon.so
 
+TARGET = ../gcc-arm-none-eabi-5_4-2016q2-linux-x86
+TARGET_CXX = $(TARGET)/bin/arm-none-eabi-g++
+TARGET_CXX_VERSION = $(shell $(TARGET_CXX) -dumpversion | awk -F "." '{print $$1}')
+TARGET_PLUGIN_DIR  = $(shell $(TARGET_CXX) -print-file-name=plugin)/include
+
+CXXFLAGS = -std=c++11
+CXXFLAGS += -Wall -Wno-literal-suffix
+CXXFLAGS += -fno-rtti
+CXXFLAGS += -m32
+CXXFLAGS += -fPIC
+CXXFLAGS += -I$(TARGET_PLUGIN_DIR)
+CXXFLAGS += -DTARGET_CXX_VERSION=$(TARGET_CXX_VERSION)
+
 nexmon.so: nexmon.o
-	g++ -m32 -shared -o $@ $<
+	g++ -$(CXXFLAGS) -shared -o $@ $<
 
 nexmon.o: nexmon.c
-	g++ -std=c++11 -Wall -fno-rtti -Wno-literal-suffix -m32 -fPIC -I../gcc-arm-none-eabi-5_4-2016q2-linux-x86/lib/gcc/arm-none-eabi/5.4.1/plugin/include -c -o $@ $<
+	g++ $(CXXFLAGS) -c -o $@ $<
 
 clean:
 	rm -f *.o *.so

--- a/buildtools/gcc-nexmon-plugin/nexmon.c
+++ b/buildtools/gcc-nexmon-plugin/nexmon.c
@@ -1,4 +1,9 @@
+#if TARGET_CXX_VERSION >= 6
+#include <gcc-plugin.h>
+#else
 #include <plugin.h>
+#endif
+
 #include <tree.h>
 #include <print-tree.h>
 #include <stdio.h>
@@ -28,8 +33,13 @@ static struct attribute_spec user_attr =
 	.decl_required = true,
 	.type_required = false,
 	.function_type_required = false,
+#if TARGET_CXX_VERSION >= 6
+	.affects_type_identity = false,
+	.handler = handle_nexmon_place_at_attribute,
+#else
 	.handler = handle_nexmon_place_at_attribute,
 	.affects_type_identity = false,
+#endif
 };
 
 static tree


### PR DESCRIPTION
Hey guys,

I faced issues when compiling your tree with more recent target toolchains (the ones embedded in the tree are 5.4+).

I found that the right way to include the plugin development headers is now #include <gcc-plugin.h>

For portability reason, I introduce a -DTARGET_CXX_VERSION= flag, which in the original case will equal 5, but for instance might equal 8 if I point to a newer toolchain.

That is why I modify #include <plugin.h> in nexmon.c if necessary

In newer toolchains the 'attribute_specs' structure has new attributes, which causes the previous construction to fail because the ordering is no longer respected. Therefore I also propose a reordering, if necessary