### PR TITLE
docs: fix simple typo, statictics -> statistics

### DIFF
--- a/utilities/wireshark/ui/cli/tap-httpstat.c
+++ b/utilities/wireshark/ui/cli/tap-httpstat.c
@@ -36,7 +36,7 @@
 
 void register_tap_listener_httpstat(void);
 
-/* used to keep track of the statictics for an entire program interface */
+/* used to keep track of the statistics for an entire program interface */
 typedef struct _http_stats_t {
 	char 		*filter;
 	GHashTable	*hash_responses;

--- a/utilities/wireshark/ui/cli/tap-rtspstat.c
+++ b/utilities/wireshark/ui/cli/tap-rtspstat.c
@@ -39,7 +39,7 @@
 
 void register_tap_listener_rtspstat(void);
 
-/* used to keep track of the statictics for an entire program interface */
+/* used to keep track of the statistics for an entire program interface */
 typedef struct _rtsp_stats_t {
 	char 		*filter;
 	GHashTable	*hash_responses;

--- a/utilities/wireshark/ui/cli/tap-sipstat.c
+++ b/utilities/wireshark/ui/cli/tap-sipstat.c
@@ -38,7 +38,7 @@
 
 void register_tap_listener_sipstat(void);
 
-/* used to keep track of the statictics for an entire program interface */
+/* used to keep track of the statistics for an entire program interface */
 typedef struct _sip_stats_t {
 	char	    *filter;
 	guint32	     packets;	 /* number of sip packets, including continuations */

--- a/utilities/wireshark/ui/cli/tap-wspstat.c
+++ b/utilities/wireshark/ui/cli/tap-wspstat.c
@@ -51,7 +51,7 @@ typedef struct _wsp_status_code_t {
 	const gchar	*name;
 	guint32		 packets;
 } wsp_status_code_t;
-/* used to keep track of the statictics for an entire program interface */
+/* used to keep track of the statistics for an entire program interface */
 typedef struct _wsp_stats_t {
 	char 		*filter;
 	wsp_pdu_t 	*pdu_stats;


### PR DESCRIPTION
There is a small typo in utilities/wireshark/ui/cli/tap-httpstat.c, utilities/wireshark/ui/cli/tap-rtspstat.c, utilities/wireshark/ui/cli/tap-sipstat.c, utilities/wireshark/ui/cli/tap-wspstat.c.

Should read `statistics` rather than `statictics`.

