### PR TITLE
Add citation file to support GitHub's repository citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,29 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+  - given-names: Matthias
+    family-names: Schulz
+    email: mschulz@seemoo.tu-darmstadt.de
+    affiliation: Secure Mobile Networking Lab
+  - given-names: Daniel
+    family-names: Wegemer
+    email: dwegemer@seemoo.tu-darmstadt.de
+    affiliation: Secure Mobile Networking Lab
+  - given-names: Matthias
+    family-names: Hollick
+    email: mhollick@seemoo.tu-darmstadt.de
+    affiliation: Secure Mobile Networking Lab
+title: "Nexmon: The C-based Firmware Patching Framework"
+version: 2.2.2
+type: software
+date-released: 2017-09-29
+url: "https://github.com/seemoo-lab/nexmon"
+keywords:
+  - rpi
+  - framework
+  - firmware
+  - broadcom
+  - smartphone
+  - patching
+  - nexmon
+license: GPL-3.0


### PR DESCRIPTION
This PR adds the `CITATION.cff` file, following the [Citation File Format](https://citation-file-format.github.io/).
GitHub can use this information to create a button where it's easy to copy the citation for BibTeX.

The citation file contains a little more information than the BibTeX citation provided in the README file. I took the keywords from the "About" section on GitHub, but perhaps you might want to edit these in the citation file.

It looks like this on GitHub:
<img width="504" alt="image" src="https://github.com/seemoo-lab/nexmon/assets/38211057/ad03b52f-b732-466f-a8c8-9e2f5c06638e">