### PR TITLE
strdup and kstrdup: null pointer checks

### DIFF
--- a/patches/driver/brcmfmac_5.15.y-nexmon/firmware.c
+++ b/patches/driver/brcmfmac_5.15.y-nexmon/firmware.c
@@ -617,6 +617,7 @@ static char *brcm_alt_fw_path(const char *path, const char *board_type)
 {
 	char alt_path[BRCMF_FW_NAME_LEN];
 	char suffix[5];
+	char *ret = NULL;
 
 	strscpy(alt_path, path, BRCMF_FW_NAME_LEN);
 	/* At least one character + suffix */
@@ -629,8 +630,13 @@ static char *brcm_alt_fw_path(const char *path, const char *board_type)
 	strlcat(alt_path, ".", BRCMF_FW_NAME_LEN);
 	strlcat(alt_path, board_type, BRCMF_FW_NAME_LEN);
 	strlcat(alt_path, suffix, BRCMF_FW_NAME_LEN);
-
-	return kstrdup(alt_path, GFP_KERNEL);
+	ret = kstrdup(alt_path, GFP_KERNEL);
+	if (!ret) {
+		brcmf_err("failed to allocate memory for alt_path\n");
+		return NULL;
+	}
+		
+	return ret;
 }
 
 static int brcmf_fw_request_firmware(const struct firmware **fw,

--- a/patches/driver/brcmfmac_6.1.y-nexmon/firmware.c
+++ b/patches/driver/brcmfmac_6.1.y-nexmon/firmware.c
@@ -608,6 +608,7 @@ static char *brcm_alt_fw_path(const char *path, const char *board_type)
 {
 	char alt_path[BRCMF_FW_NAME_LEN];
 	char suffix[5];
+	char *ret = NULL;
 
 	strscpy(alt_path, path, BRCMF_FW_NAME_LEN);
 	/* At least one character + suffix */
@@ -620,6 +621,10 @@ static char *brcm_alt_fw_path(const char *path, const char *board_type)
 	strlcat(alt_path, ".", BRCMF_FW_NAME_LEN);
 	strlcat(alt_path, board_type, BRCMF_FW_NAME_LEN);
 	strlcat(alt_path, suffix, BRCMF_FW_NAME_LEN);
+	if (!ret) {
+		brcmf_err("failed to allocate memory for alt_path\n");
+		return NULL;
+	}
 
 	return kstrdup(alt_path, GFP_KERNEL);
 }

--- a/patches/driver/brcmfmac_6.2.y-nexmon/firmware.c
+++ b/patches/driver/brcmfmac_6.2.y-nexmon/firmware.c
@@ -608,6 +608,7 @@ static char *brcm_alt_fw_path(const char *path, const char *board_type)
 {
 	char alt_path[BRCMF_FW_NAME_LEN];
 	char suffix[5];
+	char *ret = NULL;
 
 	strscpy(alt_path, path, BRCMF_FW_NAME_LEN);
 	/* At least one character + suffix */
@@ -620,6 +621,10 @@ static char *brcm_alt_fw_path(const char *path, const char *board_type)
 	strlcat(alt_path, ".", BRCMF_FW_NAME_LEN);
 	strlcat(alt_path, board_type, BRCMF_FW_NAME_LEN);
 	strlcat(alt_path, suffix, BRCMF_FW_NAME_LEN);
+	if (!ret) {
+		brcmf_err("failed to allocate memory for alt_path\n");
+		return NULL;
+	}
 
 	return kstrdup(alt_path, GFP_KERNEL);
 }

--- a/patches/driver/brcmfmac_6.6.y-nexmon/firmware.c
+++ b/patches/driver/brcmfmac_6.6.y-nexmon/firmware.c
@@ -608,6 +608,7 @@ static char *brcm_alt_fw_path(const char *path, const char *board_type)
 {
 	char alt_path[BRCMF_FW_NAME_LEN];
 	char suffix[5];
+	char *ret;
 
 	strscpy(alt_path, path, BRCMF_FW_NAME_LEN);
 	/* At least one character + suffix */
@@ -620,6 +621,10 @@ static char *brcm_alt_fw_path(const char *path, const char *board_type)
 	strlcat(alt_path, ".", BRCMF_FW_NAME_LEN);
 	strlcat(alt_path, board_type, BRCMF_FW_NAME_LEN);
 	strlcat(alt_path, suffix, BRCMF_FW_NAME_LEN);
+	if (!ret) {
+		brcmf_err("failed to allocate memory for alt_path\n");
+		return NULL;
+	}
 
 	return kstrdup(alt_path, GFP_KERNEL);
 }

--- a/utilities/aircrack-ng/src/aircrack-ng.c
+++ b/utilities/aircrack-ng/src/aircrack-ng.c
@@ -710,6 +710,11 @@ int mergebssids(char * bssidlist, unsigned char * bssid)
 	mac[17] = 0;
 
 	tmp2 = list = strdup(bssidlist);
+	if (list == NULL)
+	{
+		perror( "strdup failed" );
+		return -1;
+	}
 
 	// skip first element (because it doesn't have to be converted
 	// It already has the good value


### PR DESCRIPTION
The lib func `strdup` and `kstrdup` may return null pointers on memory allocation failures.

I added checks for the unchecked calls to those two functions.

Specifically, for the four `firmware.c` files in different patches, the null pointer is actually **checked by the caller function**. But it lacks an error message that indicates what happened.

For `utilities/aircrack-ng/src/aircrack-ng.c`, the following API `strsep` can indeed handle NULL pointers, but the program would silently go wrong. So I added an explicit error message.