### PR TITLE
bcm4375: added firmware patch for version 18.41.117

### DIFF
--- a/patches/bcm4375b1/18_41_117_sta/nexmon/Makefile
+++ b/patches/bcm4375b1/18_41_117_sta/nexmon/Makefile
@@ -1,0 +1,216 @@
+GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags)
+SHELL := /bin/bash
+include ../version.mk
+include $(FW_PATH)/definitions.mk
+
+LOCAL_SRCS=$(wildcard src/*.c) src/ucode1_compressed.c src/ucode2_compressed.c src/templateram0.c src/templateram1.c src/templateram2.c
+COMMON_SRCS=$(wildcard $(NEXMON_ROOT)/patches/common/*.c)
+FW_SRCS=$(wildcard $(FW_PATH)/*.c)
+
+OBJS=$(addprefix obj/,$(notdir $(LOCAL_SRCS:.c=.o)) $(notdir $(COMMON_SRCS:.c=.o)) $(notdir $(FW_SRCS:.c=.o)))
+
+CFLAGS= \
+	-fplugin=$(CCPLUGIN) \
+	-fplugin-arg-nexmon-objfile=$@ \
+	-fplugin-arg-nexmon-prefile=gen/nexmon.pre \
+	-fplugin-arg-nexmon-chipver=$(NEXMON_CHIP_NUM) \
+	-fplugin-arg-nexmon-fwver=$(NEXMON_FW_VERSION_NUM) \
+	-fno-strict-aliasing \
+	-DNEXMON_CHIP=$(NEXMON_CHIP) \
+	-DNEXMON_FW_VERSION=$(NEXMON_FW_VERSION) \
+	-DWLC_UCODE_WRITE_BL_HOOK_ADDR=$(WLC_UCODE_WRITE_BL_HOOK_ADDR) \
+	-DUCODE1START_PTR=$(UCODE1START_PTR) \
+	-DUCODE1SIZE_PTR=$(UCODE1SIZE_PTR) \
+	-DUCODE2START_PTR=$(UCODE2START_PTR) \
+	-DUCODE2SIZE_PTR=$(UCODE2SIZE_PTR) \
+	-DHNDRTE_RECLAIM_0_END_PTR=$(HNDRTE_RECLAIM_0_END_PTR) \
+	-DTEMPLATERAMSTART0_PTR=$(TEMPLATERAMSTART0_PTR) \
+	-DTEMPLATERAMSTART1_PTR=$(TEMPLATERAMSTART1_PTR) \
+	-DTEMPLATERAMSTART2_PTR=$(TEMPLATERAMSTART2_PTR) \
+	-DVASIPSTART_PTR=$(VASIPSTART_PTR) \
+	-DFP_CONFIG_ORIGBASE=$(FP_CONFIG_ORIGBASE) \
+	-DFP_CONFIG_ORIGEND=$(FP_CONFIG_ORIGEND) \
+	-DPATCHSTART=$(PATCHSTART) \
+	-DUCODESIZE=$(UCODESIZE) \
+	-DGIT_VERSION=\"$(GIT_VERSION)\" \
+	-DBUILD_NUMBER=\"$$(cat BUILD_NUMBER)\" \
+	-Wall -Werror -O2 -nostdlib -nostartfiles -ffreestanding -mthumb -march=$(NEXMON_ARCH) \
+	-ffunction-sections -fdata-sections \
+	-I$(NEXMON_ROOT)/patches/include \
+	-Iinclude \
+	-I$(FW_PATH)
+
+all: $(RAM_FILE)
+
+init: FORCE
+	$(Q)if ! test -f BUILD_NUMBER; then echo 0 > BUILD_NUMBER; fi
+	$(Q)echo $$(($$(cat BUILD_NUMBER) + 1)) > BUILD_NUMBER
+	$(Q)touch src/version.c
+	$(Q)make -s -f $(NEXMON_ROOT)/patches/common/header.mk
+	$(Q)mkdir -p obj gen log
+
+obj/%.o: src/%.c
+	@printf "\033[0;31m  COMPILING\033[0m %s => %s (details: log/compiler.log)\n" $< $@
+	$(Q)cat gen/nexmon.pre 2>>log/error.log | gawk '{ if ($$3 != "$@") print; }' > tmp && mv tmp gen/nexmon.pre
+	$(Q)$(CC)gcc $(CFLAGS) -c $< -o $@ >>log/compiler.log
+
+obj/%.o: $(NEXMON_ROOT)/patches/common/%.c
+	@printf "\033[0;31m  COMPILING\033[0m %s => %s (details: log/compiler.log)\n" $< $@
+	$(Q)cat gen/nexmon.pre 2>>log/error.log | gawk '{ if ($$3 != "$@") print; }' > tmp && mv tmp gen/nexmon.pre
+	$(Q)$(CC)gcc $(CFLAGS) -c $< -o $@ >>log/compiler.log
+
+obj/%.o: $(FW_PATH)/%.c
+	@printf "\033[0;31m  COMPILING\033[0m %s => %s (details: log/compiler.log)\n" $< $@
+	$(Q)cat gen/nexmon.pre 2>>log/error.log | gawk '{ if ($$3 != "$@") print; }' > tmp && mv tmp gen/nexmon.pre
+	$(Q)$(CC)gcc $(CFLAGS) -c $< -o $@ >>log/compiler.log
+
+gen/nexmon2.pre: $(OBJS)
+	@printf "\033[0;31m  PREPARING\033[0m %s => %s\n" "gen/nexmon.pre" $@
+	$(Q)cat gen/nexmon.pre | awk '{ if ($$3 != "obj/flashpatches.o" && $$3 != "obj/wrapper.o" && $$3 != "obj/local_wrapper.o") { print $$0; } }' > tmp
+	$(Q)cat gen/nexmon.pre | awk '{ if ($$3 == "obj/flashpatches.o" || $$3 == "obj/wrapper.o" || $$3 == "obj/local_wrapper.o") { print $$0; } }' >> tmp
+	$(Q)cat tmp | awk '{ if ($$1 ~ /^0x/) { if ($$3 != "obj/flashpatches.o" && $$3 != "obj/wrapper.o" && $$3 != "obj/local_wrapper.o") { if (!x[$$1]++) { print $$0; } } else { if (!x[$$1]) { print $$0; } } } else { print $$0; } }' > gen/nexmon2.pre
+
+gen/nexmon.ld: gen/nexmon2.pre $(OBJS)
+	@printf "\033[0;31m  GENERATING LINKER FILE\033[0m gen/nexmon.pre => %s\n" $@
+	$(Q)sort gen/nexmon2.pre | gawk -f $(NEXMON_ROOT)/buildtools/scripts/nexmon.ld.awk > $@
+
+gen/nexmon.mk: gen/nexmon2.pre $(OBJS) $(FW_PATH)/definitions.mk
+	@printf "\033[0;31m  GENERATING MAKE FILE\033[0m gen/nexmon.pre => %s\n" $@
+	$(Q)printf "$(RAM_FILE): gen/patch.elf FORCE\n" > $@
+	$(Q)sort gen/nexmon2.pre | \
+		gawk -v src_file=gen/patch.elf -f $(NEXMON_ROOT)/buildtools/scripts/nexmon.mk.1.awk | \
+		gawk -v ramstart=$(RAMSTART) -f $(NEXMON_ROOT)/buildtools/scripts/nexmon.mk.2.awk >> $@
+	$(Q)printf "\nFORCE:\n" >> $@
+	$(Q)gawk '!a[$$0]++' $@ > tmp && mv tmp $@
+
+gen/flashpatches.ld: gen/nexmon2.pre $(OBJS)
+	@printf "\033[0;31m  GENERATING LINKER FILE\033[0m gen/nexmon.pre => %s\n" $@
+	$(Q)sort gen/nexmon2.pre | \
+		gawk -f $(NEXMON_ROOT)/buildtools/scripts/flashpatches.ld.awk > $@
+
+gen/flashpatches.mk: gen/nexmon2.pre $(OBJS) $(FW_PATH)/definitions.mk
+	@printf "\033[0;31m  GENERATING MAKE FILE\033[0m gen/nexmon.pre => %s\n" $@
+	$(Q)cat gen/nexmon2.pre | gawk \
+		-v fp_data_base=$(FP_DATA_BASE) \
+		-v fp_config_base=$(FP_CONFIG_BASE) \
+		-v fp_config_base_ptr_1=$(FP_CONFIG_BASE_PTR_1) \
+		-v fp_config_end_ptr_1=$(FP_CONFIG_END_PTR_1) \
+		-v fp_config_base_ptr_2=$(FP_CONFIG_BASE_PTR_2) \
+		-v fp_config_end_ptr_2=$(FP_CONFIG_END_PTR_2) \
+		-v ramstart=$(RAMSTART) \
+		-v out_file=$(RAM_FILE) \
+		-v src_file=gen/patch.elf \
+		-f $(NEXMON_ROOT)/buildtools/scripts/flashpatches.bcm4375.mk.awk > $@
+
+gen/memory.ld: $(FW_PATH)/definitions.mk
+	@printf "\033[0;31m  GENERATING LINKER FILE\033[0m %s\n" $@
+	$(Q)printf "rom : ORIGIN = 0x%08x, LENGTH = 0x%08x\n" $(ROMSTART) $(ROMSIZE) > $@
+	$(Q)printf "ram : ORIGIN = 0x%08x, LENGTH = 0x%08x\n" $(RAMSTART) $(RAMSIZE) >> $@
+	$(Q)printf "patch : ORIGIN = 0x%08x, LENGTH = 0x%08x\n" $(PATCHSTART) $(PATCHSIZE) >> $@
+	$(Q)printf "ucode : ORIGIN = 0x%08x, LENGTH = 0x%08x\n" $(UCODE1START) $$(($(FP_CONFIG_BASE) - $(UCODE1START))) >> $@
+	$(Q)printf "fpconfig : ORIGIN = 0x%08x, LENGTH = 0x%08x\n" $(FP_CONFIG_BASE) $(FP_CONFIG_SIZE) >> $@
+
+gen/patch.elf: patch.ld gen/nexmon.ld gen/flashpatches.ld gen/memory.ld $(OBJS)
+	@printf "\033[0;31m  LINKING OBJECTS\033[0m => %s (details: log/linker.log, log/linker.err)\n" $@
+	$(Q)$(CC)ld -T $< -o $@ --gc-sections --print-gc-sections -M >>log/linker.log 2>>log/linker.err
+
+$(RAM_FILE): init gen/patch.elf $(FW_PATH)/$(RAM_FILE) gen/nexmon.mk gen/flashpatches.mk
+	$(Q)cp $(FW_PATH)/$(RAM_FILE) $@
+	@printf "\033[0;31m  APPLYING FLASHPATCHES\033[0m gen/flashpatches.mk => %s (details: log/flashpatches.log)\n" $@
+	$(Q)make -f gen/flashpatches.mk >>log/flashpatches.log 2>>log/flashpatches.log
+	@printf "\033[0;31m  APPLYING PATCHES\033[0m gen/nexmon.mk => %s (details: log/patches.log)\n" $@
+	$(Q)make -f gen/nexmon.mk >>log/patches.log 2>>log/flashpatches.log
+
+fw_bcmdhd.complete.clean.bin: $(FW_PATH)/$(RAM_FILE) $(FW_PATH)/$(ROM_FILE)
+	dd if=$(FW_PATH)/$(ROM_FILE) of=$@ bs=1 status=none conv=notrunc seek=$$(($(ROMSTART)))
+	dd if=$< of=$@ bs=1 status=none conv=notrunc seek=$$(($(RAMSTART)))
+
+fw_bcmdhd.complete.bin: $(RAM_FILE) $(FW_PATH)/$(ROM_FILE)
+	dd if=$(FW_PATH)/$(ROM_FILE) of=$@ bs=1 status=none conv=notrunc seek=$$(($(ROMSTART)))
+	dd if=$< of=$@ bs=1 status=none conv=notrunc seek=$$(($(RAMSTART)))
+
+###################################################################
+# ucode compression related
+###################################################################
+
+gen/ucode1.bin: $(FW_PATH)/ucode1.bin
+	@printf "\033[0;31m  COPYING UCODE1\033[0m %s => %s\n" $< $@
+	$(Q)cp $< $@
+
+gen/ucode2.bin: $(FW_PATH)/ucode2.bin
+	@printf "\033[0;31m  COPYING UCODE2\033[0m %s => %s\n" $< $@
+	$(Q)cp $< $@
+
+gen/ucode1_compressed.bin: gen/ucode1.bin
+	@printf "\033[0;31m  COMPRESSING UCODE1\033[0m %s => %s\n" $< $@
+	$(Q)cat $< | $(ZLIBFLATE) > $@
+
+gen/ucode2_compressed.bin: gen/ucode2.bin
+	@printf "\033[0;31m  COMPRESSING UCODE2\033[0m %s => %s\n" $< $@
+	$(Q)cat $< | $(ZLIBFLATE) > $@
+
+src/ucode1_compressed.c: gen/ucode1_compressed.bin
+	@printf "\033[0;31m  GENERATING C FILE\033[0m %s => %s\n" $< $@
+	$(Q)printf "#pragma NEXMON targetregion \"ucode\"\n\n" > $@
+	$(Q)cd $(dir $<) && xxd -i $(notdir $<) >> $(shell pwd)/$@
+
+src/ucode2_compressed.c: gen/ucode2_compressed.bin
+	@printf "\033[0;31m  GENERATING C FILE\033[0m %s => %s\n" $< $@
+	$(Q)printf "#pragma NEXMON targetregion \"ucode\"\n\n" > $@
+	$(Q)cd $(dir $<) && xxd -i $(notdir $<) >> $(shell pwd)/$@
+
+
+src/templateram0.c: $(FW_PATH)/templateram0.bin
+	@printf "\033[0;31m  GENERATING C FILE\033[0m %s => %s\n" $< $@
+	$(Q)printf "#pragma NEXMON targetregion \"ucode\"\n\n" > $@
+	$(Q)cd $(dir $<) && xxd -i $(notdir $<) >> $(shell pwd)/$@
+
+src/templateram1.c: $(FW_PATH)/templateram1.bin
+	@printf "\033[0;31m  GENERATING C FILE\033[0m %s => %s\n" $< $@
+	$(Q)printf "#pragma NEXMON targetregion \"ucode\"\n\n" > $@
+	$(Q)cd $(dir $<) && xxd -i $(notdir $<) >> $(shell pwd)/$@
+
+src/templateram2.c: $(FW_PATH)/templateram2.bin
+	@printf "\033[0;31m  GENERATING C FILE\033[0m %s => %s\n" $< $@
+	$(Q)printf "#pragma NEXMON targetregion \"ucode\"\n\n" > $@
+	$(Q)cd $(dir $<) && xxd -i $(notdir $<) >> $(shell pwd)/$@
+
+src/vasip.c: $(FW_PATH)/vasip.bin
+	@printf "\033[0;31m  GENERATING C FILE\033[0m %s => %s\n" $< $@
+	$(Q)printf "#pragma NEXMON targetregion \"ucode\"\n\n" > $@
+	$(Q)cd $(dir $<) && xxd -i $(notdir $<) >> $(shell pwd)/$@
+
+###################################################################
+
+check-nexmon-setup-env:
+ifndef NEXMON_SETUP_ENV
+	$(error run 'source setup_env.sh' first in the repository\'s root directory)
+endif
+
+dump-rom: FORCE
+	@printf "\033[0;31m  DUMPING ROM TO\033[0m /var/root/romdump.bin\n"
+	adb shell "su -c 'nexutil -g0x602 -l1024 -i -v0x0 -r'" > rom.bin && for n in {1..1343}; do adb shell "su -c 'nexutil -g0x602 -l1024 -i -v$$(($$n*1024)) -r'" >> rom.bin; done
+
+install-firmware: $(RAM_FILE)
+	@printf "\033[0;31m  REMOUNTING /system\033[0m\n"
+	$(Q)adb shell 'su -c "mount -o rw,remount /system"'
+	@printf "\033[0;31m  COPYING TO PHONE\033[0m %s => /sdcard/%s\n" $< $<
+	$(Q)adb push $< /sdcard/ >> log/adb.log 2>> log/adb.log
+	@printf "\033[0;31m  COPYING\033[0m /sdcard/$(RAM_FILE) => /vendor/etc/wifi/$(RAM_FILE)\n"
+	$(Q)adb shell 'su -c "cp /sdcard/$(RAM_FILE) /vendor/etc/wifi/$(RAM_FILE)"'
+	@printf "\033[0;31m  RELOADING FIRMWARE\033[0m\n"
+	$(Q)adb shell 'su -c "ifconfig wlan0 down && ifconfig wlan0 up"'
+
+install-remote: $(RAM_FILE)
+	scp $(RAM_FILE) s20:~
+	ssh s20 "cp bcmdhd_sta.bin_b1 /data/tmpfs/"
+#	ssh s20 "unchroot /data/tmpfs/install"
+
+clean-firmware: FORCE
+	@printf "\033[0;31m  CLEANING\033[0m\n"
+	$(Q)rm -fr $(RAM_FILE) obj gen log src/ucode1_compressed.c src/ucode2_compressed.c src/templateram0.c src/templateram1.c src/templateram2.c src/vasip.c
+
+clean: clean-firmware
+	$(Q)rm -f BUILD_NUMBER
+
+FORCE:

--- a/patches/bcm4375b1/18_41_117_sta/nexmon/include/local_wrapper.h
+++ b/patches/bcm4375b1/18_41_117_sta/nexmon/include/local_wrapper.h
@@ -1,0 +1,40 @@
+/***************************************************************************
+ *                                                                         *
+ *          ###########   ###########   ##########    ##########           *
+ *         ############  ############  ############  ############          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ###########   ####  ######  ##   ##   ##  ##    ######          *
+ *          ###########  ####  #       ##   ##   ##  ##    #    #          *
+ *                   ##  ##    ######  ##   ##   ##  ##    #    #          *
+ *                   ##  ##    #       ##   ##   ##  ##    #    #          *
+ *         ############  ##### ######  ##   ##   ##  ##### ######          *
+ *         ###########    ###########  ##   ##   ##   ##########           *
+ *                                                                         *
+ *            S E C U R E   M O B I L E   N E T W O R K I N G              *
+ *                                                                         *
+ * This file is part of NexMon.                                            *
+ *                                                                         *
+ * Copyright (c) 2016 NexMon Team                                          *
+ *                                                                         *
+ * NexMon is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by    *
+ * the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                     *
+ *                                                                         *
+ * NexMon is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of          *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
+ * GNU General Public License for more details.                            *
+ *                                                                         *
+ * You should have received a copy of the GNU General Public License       *
+ * along with NexMon. If not, see <http://www.gnu.org/licenses/>.          *
+ *                                                                         *
+ **************************************************************************/
+
+#ifndef LOCAL_WRAPPER_H
+#define LOCAL_WRAPPER_H
+
+#include "../src/local_wrapper.c"        // wrapper definitions for functions that already exist in the firmware
+
+#endif /*LOCAL_WRAPPER_H*/

--- a/patches/bcm4375b1/18_41_117_sta/nexmon/include/vendor_radiotap.h
+++ b/patches/bcm4375b1/18_41_117_sta/nexmon/include/vendor_radiotap.h
@@ -1,0 +1,67 @@
+/***************************************************************************
+ *                                                                         *
+ *          ###########   ###########   ##########    ##########           *
+ *         ############  ############  ############  ############          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ###########   ####  ######  ##   ##   ##  ##    ######          *
+ *          ###########  ####  #       ##   ##   ##  ##    #    #          *
+ *                   ##  ##    ######  ##   ##   ##  ##    #    #          *
+ *                   ##  ##    #       ##   ##   ##  ##    #    #          *
+ *         ############  ##### ######  ##   ##   ##  ##### ######          *
+ *         ###########    ###########  ##   ##   ##   ##########           *
+ *                                                                         *
+ *            S E C U R E   M O B I L E   N E T W O R K I N G              *
+ *                                                                         *
+ * This file is part of NexMon.                                            *
+ *                                                                         *
+ * Copyright (c) 2016 NexMon Team                                          *
+ *                                                                         *
+ * NexMon is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by    *
+ * the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                     *
+ *                                                                         *
+ * NexMon is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of          *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
+ * GNU General Public License for more details.                            *
+ *                                                                         *
+ * You should have received a copy of the GNU General Public License       *
+ * along with NexMon. If not, see <http://www.gnu.org/licenses/>.          *
+ *                                                                         *
+ **************************************************************************/
+
+#ifndef VENDOR_RADIOTAP_H
+#define VENDOR_RADIOTAP_H
+
+extern const struct ieee80211_radiotap_vendor_namespaces rtap_vendor_namespaces;
+
+/* Name                                 Data type    	Units
+ * ----                                 ---------    	-----
+ *
+ * RADIOTAP_NEX_TXDELAY               	s32	    		milliseconds
+ *
+ *      Value in milliseconds to wait before transmitting this frame
+ *		for the first time
+ *
+ * RADIOTAP_NEX_TXREPETITIONS        	2 x s32    		unitless, milliseconds
+ *
+ *      Amount of how often this frame should be transmitted and the
+ *		periodicity in milliseconds of the retransmissions. Setting
+ *		the number of retransmissions to -1 leads to infinite 
+ *		retransmissions
+ *
+ * RADIOTAP_NEX_RATESPEC               	u32	    		unitless
+ *
+ *      Define the ratespec according to the definitions in rates.h
+ *		This value overrides the rate settings in the regular 
+ *		radiotap header
+ */
+enum radiotap_nex_vendor_subns_0_type {
+    RADIOTAP_NEX_TXDELAY = 0,
+    RADIOTAP_NEX_TXREPETITIONS = 1,
+    RADIOTAP_NEX_RATESPEC = 2
+};
+
+#endif /* VENDOR_RADIOTAP_H */

--- a/patches/bcm4375b1/18_41_117_sta/nexmon/patch.ld
+++ b/patches/bcm4375b1/18_41_117_sta/nexmon/patch.ld
@@ -1,0 +1,10 @@
+MEMORY
+{
+	INCLUDE gen/memory.ld
+}
+
+SECTIONS
+{
+	INCLUDE gen/flashpatches.ld
+	INCLUDE gen/nexmon.ld
+}

--- a/patches/bcm4375b1/18_41_117_sta/nexmon/src/console.c
+++ b/patches/bcm4375b1/18_41_117_sta/nexmon/src/console.c
@@ -1,0 +1,163 @@
+/***************************************************************************
+ *                                                                         *
+ *          ###########   ###########   ##########    ##########           *
+ *         ############  ############  ############  ############          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ###########   ####  ######  ##   ##   ##  ##    ######          *
+ *          ###########  ####  #       ##   ##   ##  ##    #    #          *
+ *                   ##  ##    ######  ##   ##   ##  ##    #    #          *
+ *                   ##  ##    #       ##   ##   ##  ##    #    #          *
+ *         ############  ##### ######  ##   ##   ##  ##### ######          *
+ *         ###########    ###########  ##   ##   ##   ##########           *
+ *                                                                         *
+ *            S E C U R E   M O B I L E   N E T W O R K I N G              *
+ *                                                                         *
+ * This file is part of NexMon.                                            *
+ *                                                                         *
+ * Copyright (c) 2016 NexMon Team                                          *
+ *                                                                         *
+ * NexMon is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by    *
+ * the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                     *
+ *                                                                         *
+ * NexMon is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of          *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
+ * GNU General Public License for more details.                            *
+ *                                                                         *
+ * You should have received a copy of the GNU General Public License       *
+ * along with NexMon. If not, see <http://www.gnu.org/licenses/>.          *
+ *                                                                         *
+ **************************************************************************/
+
+#pragma NEXMON targetregion "patch"
+
+#include <firmware_version.h>   // definition of firmware version macros
+#include <debug.h>              // contains macros to access the debug hardware
+#include <wrapper.h>            // wrapper definitions for functions that already exist in the firmware
+#include <structs.h>            // structures that are used by the code in the firmware
+#include <helper.h>             // useful helper functions
+#include <patcher.h>            // macros used to craete patches such as BLPatch, BPatch, ...
+#include <rates.h>              // rates used to build the ratespec for frame injection
+#include <local_wrapper.h>
+
+#define LOG_BUF_LEN     (4*1024)
+
+static char console_buf[LOG_BUF_LEN] = {0};
+
+typedef struct {
+    char        *buf;
+    uint32_t    buf_size;
+    uint32_t    idx;
+} hndrte_log_t;
+
+hndrte_log_t active_log = {
+    .buf = console_buf,
+    .buf_size = LOG_BUF_LEN,
+    .idx = 0
+};
+
+void
+clearconsole(void)
+{
+    int i = 0;
+    for (i = 0; i < LOG_BUF_LEN; i++) {
+        console_buf[i] = 0;
+    }
+
+    active_log.idx = 0;
+}
+
+void
+putc(int c)
+{
+    hndrte_log_t *log = &active_log;
+
+    /* CR before LF */
+    if (c == '\n')
+        putc('\r');
+
+    if (log->buf != 0) {
+        int idx = log->idx;
+
+        /* Store in log buffer */
+        log->buf[idx] = (char)c;
+        log->idx = (idx + 1) % LOG_BUF_LEN;
+    }
+}
+
+int
+vprintf(void *lr, void *sp, const char *fmt, va_list va)
+{
+    char line_buf[256] = { 0 };
+
+    if (active_log.buf[(active_log.idx - 1) % active_log.buf_size] == '\n') {
+        uint32_t time = hndrte_time_ms();
+        int written = 0;
+
+        switch ((int) lr) {
+            case 0x1855e7:
+                // at offset 17 uint32_t values of the sp, we find the pused link register
+                written = snprintf(line_buf, sizeof(line_buf) - 3 - written, "%03u.%03u %06x %06x ", time / 1000, time % 1000, lr, ((uint32_t *) sp)[17]);
+                break;
+            case 0xd4e9:
+                // at offset 23 uint32_t values of the sp, we find the pused link register
+                written = snprintf(line_buf, sizeof(line_buf) - 3 - written, "%03u.%03u %06x %06x ", time / 1000, time % 1000, lr, ((uint32_t *) sp)[23]);
+                //hexdump("printf", sp, 50*4);
+                break;
+            case 0x1854ad:
+                // at offset 23 uint32_t values of the sp, we find the pused link register
+                written = snprintf(line_buf, sizeof(line_buf) - 3 - written, "%03u.%03u %06x %06x ", time / 1000, time % 1000, lr, ((uint32_t *) sp)[15]);
+                //for (int i = 0; i < 50; i++)
+                //    printf("%02d %08x\n", i, ((uint32_t *) sp)[i]);
+                break;
+            default:
+                written = snprintf(line_buf, sizeof(line_buf) - 3 - written, "%03u.%03u %06x ", time / 1000, time % 1000, lr);
+        }
+        if (written >= 0 && written < sizeof(line_buf) - 3 - written)
+            vsnprintf(line_buf + written, sizeof(line_buf) -3 - written, fmt, va);
+    } else {
+        vsnprintf(line_buf, sizeof(line_buf)-3, fmt, va);
+    }
+
+    for (char *c = line_buf; *c != 0; c++) {
+        putc(*c);
+    }
+
+    return 0;
+}
+
+#if 1
+int
+printf(const char *fmt, ...)
+{
+    void *lr = 0x0;
+    void *sp = 0x0;
+    int ret = 0;
+    __asm("mov %0, lr" : "=r" (lr));
+    __asm("mov %0, sp" : "=r" (sp));
+
+    va_list va;
+    va_start(va,fmt);
+    ret = vprintf(lr, sp, fmt, va);
+    va_end(va);
+
+    return ret;
+}
+
+__attribute__((at(0x89D0, "flashpatch", CHIP_VER_BCM4375b1, FW_VER_18_38_18_sta)))
+__attribute__((naked))
+void
+printf_hook(void)
+{
+// HINT: the flashpatches on the BCM4375 are always 8 byte long and also aligned
+// on an 8 byte boundary, hence, we need to add the bytes that will be overwritten
+// by the flashpatch
+    asm(
+        "b printf\n"
+        ".byte 0x00, 0x00, 0x00, 0x00"
+    );
+}
+#endif

--- a/patches/bcm4375b1/18_41_117_sta/nexmon/src/injection.c
+++ b/patches/bcm4375b1/18_41_117_sta/nexmon/src/injection.c
@@ -1,0 +1,74 @@
+/***************************************************************************
+ *                                                                         *
+ *          ###########   ###########   ##########    ##########           *
+ *         ############  ############  ############  ############          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ###########   ####  ######  ##   ##   ##  ##    ######          *
+ *          ###########  ####  #       ##   ##   ##  ##    #    #          *
+ *                   ##  ##    ######  ##   ##   ##  ##    #    #          *
+ *                   ##  ##    #       ##   ##   ##  ##    #    #          *
+ *         ############  ##### ######  ##   ##   ##  ##### ######          *
+ *         ###########    ###########  ##   ##   ##   ##########           *
+ *                                                                         *
+ *            S E C U R E   M O B I L E   N E T W O R K I N G              *
+ *                                                                         *
+ * This file is part of NexMon.                                            *
+ *                                                                         *
+ * Copyright (c) 2016 NexMon Team                                          *
+ *                                                                         *
+ * NexMon is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by    *
+ * the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                     *
+ *                                                                         *
+ * NexMon is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of          *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
+ * GNU General Public License for more details.                            *
+ *                                                                         *
+ * You should have received a copy of the GNU General Public License       *
+ * along with NexMon. If not, see <http://www.gnu.org/licenses/>.          *
+ *                                                                         *
+ **************************************************************************/
+
+#pragma NEXMON targetregion "patch"
+
+#include <firmware_version.h>   // definition of firmware version macros
+#include <debug.h>              // contains macros to access the debug hardware
+#include <wrapper.h>            // wrapper definitions for functions that already exist in the firmware
+#include <structs.h>            // structures that are used by the code in the firmware
+#include <helper.h>             // useful helper functions
+#include <patcher.h>            // macros used to craete patches such as BLPatch, BPatch, ...
+#include <rates.h>              // rates used to build the ratespec for frame injection
+#include <ieee80211_radiotap.h> // radiotap header related
+#include <vendor_radiotap.h>    // vendor specific radiotap extensions
+#include <local_wrapper.h>
+
+void *
+inject_frame(struct wlc_info *wlc, struct sk_buff *p)
+{
+    uint32_t fifo = 0;
+    uint32_t rate = RATES_RATE_6M;
+
+    struct ieee80211_radiotap_header *rtap_header;
+
+    // parse radiotap header
+    rtap_header = (struct ieee80211_radiotap_header *) p->data;
+    
+    if (wlc->monitor == 0) {
+        wlc = (struct wlc_info*) get_other_wlc(wlc);
+    }
+
+    if(wlc->monitor == 0) {
+        pkt_buf_free_skb(wlc->osh, p, 0);
+        return 0;
+    }    
+
+    // remove radiotap header
+    skb_pull(p, rtap_header->it_len);
+
+    wlc_sendctl(wlc, p, wlc->active_queue, wlc->band->hwrs_scb, fifo, rate, 0);
+
+    return 0;
+}

--- a/patches/bcm4375b1/18_41_117_sta/nexmon/src/ioctl.c
+++ b/patches/bcm4375b1/18_41_117_sta/nexmon/src/ioctl.c
@@ -1,0 +1,588 @@
+/***************************************************************************
+ *                                                                         *
+ *          ###########   ###########   ##########    ##########           *
+ *         ############  ############  ############  ############          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ###########   ####  ######  ##   ##   ##  ##    ######          *
+ *          ###########  ####  #       ##   ##   ##  ##    #    #          *
+ *                   ##  ##    ######  ##   ##   ##  ##    #    #          *
+ *                   ##  ##    #       ##   ##   ##  ##    #    #          *
+ *         ############  ##### ######  ##   ##   ##  ##### ######          *
+ *         ###########    ###########  ##   ##   ##   ##########           *
+ *                                                                         *
+ *            S E C U R E   M O B I L E   N E T W O R K I N G              *
+ *                                                                         *
+ * This file is part of NexMon.                                            *
+ *                                                                         *
+ * Copyright (c) 2016 NexMon Team                                          *
+ *                                                                         *
+ * NexMon is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by    *
+ * the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                     *
+ *                                                                         *
+ * NexMon is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of          *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
+ * GNU General Public License for more details.                            *
+ *                                                                         *
+ * You should have received a copy of the GNU General Public License       *
+ * along with NexMon. If not, see <http://www.gnu.org/licenses/>.          *
+ *                                                                         *
+ **************************************************************************/
+
+#pragma NEXMON targetregion "patch"
+
+#include <firmware_version.h>   // definition of firmware version macros
+#include <debug.h>              // contains macros to access the debug hardware
+#include <wrapper.h>            // wrapper definitions for functions that already exist in the firmware
+#include <structs.h>            // structures that are used by the code in the firmware
+#include <helper.h>             // useful helper functions
+#include <patcher.h>            // macros used to craete patches such as BLPatch, BPatch, ...
+#include <rates.h>              // rates used to build the ratespec for frame injection
+#include <nexioctls.h>          // ioctls added in the nexmon patch
+#include <capabilities.h>       // capabilities included in a nexmon patch
+#include <sendframe.h>          // sendframe functionality
+#include <version.h>            // version information
+//#include <bcmpcie.h>
+#include <argprintf.h>          // allows to execute argprintf to print into the arg buffer
+#include <local_wrapper.h>
+#include <ieee80211_radiotap.h>
+#include <udptunnel.h>
+#include <bcmwifi_channels.h>
+
+#define TXOFF 204
+
+extern char version[];
+extern char date[];
+extern char time[];
+
+struct inject_frame {
+    struct {
+    unsigned short len;
+    unsigned char pad;
+    unsigned char type;
+    } hdr;
+    char data[];
+};
+
+void *inject_frame(struct wlc_info *wlc, struct sk_buff *p);
+
+uint8_t eapol1[] = {
+  0x08, 0x02, 0x3a, 0x01, 0x82, 0x3e, 0x7a, 0x30, 0x6c, 0xa8, 0x64, 0x66,
+  0xb3, 0xce, 0x22, 0xa3, 0x64, 0x66, 0xb3, 0xce, 0x22, 0xa3, 0x00, 0x00,
+  0xaa, 0xaa, 0x03, 0x00, 0x00, 0x00, 0x88, 0x8e, 0x02, 0x03, 0x00, 0x5f,
+  0x02, 0x00, 0x8a, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x01, 0x3b, 0x75, 0xe7, 0x7e, 0x43, 0x52, 0x48, 0xa5, 0x8d, 0x20, 0x70,
+  0xb0, 0x22, 0xc5, 0x49, 0xeb, 0xf3, 0x45, 0x74, 0x78, 0xef, 0x38, 0x3a,
+  0xf0, 0x11, 0x64, 0x2e, 0xa6, 0xd7, 0xa9, 0xbe, 0xcc, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+uint8_t eapol2[] = {
+  0x08, 0x01, 0x3a, 0x01, 0x64, 0x66, 0xb3, 0xce, 0x22, 0xa3, 0x82, 0x3e,
+  0x7a, 0x30, 0x6c, 0xa8, 0x64, 0x66, 0xb3, 0xce, 0x22, 0xa3, 0x30, 0x00,
+  0xaa, 0xaa, 0x03, 0x00, 0x00, 0x00, 0x88, 0x8e, 0x01, 0x03, 0x00, 0x75,
+  0x02, 0x01, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x01, 0xe4, 0xf9, 0x79, 0x6c, 0x38, 0x84, 0x66, 0x36, 0xa8, 0x8e, 0x78,
+  0x87, 0xb1, 0x0d, 0x19, 0xc1, 0xca, 0x2a, 0x50, 0xa0, 0x28, 0xb5, 0x8d,
+  0x88, 0x37, 0x1c, 0x1f, 0xe5, 0x82, 0x84, 0x36, 0x11, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x1b, 0x3a, 0x55, 0x20, 0x5f, 0x00, 0x4a,
+  0xcd, 0x61, 0x44, 0x23, 0x55, 0x5f, 0x81, 0xbf, 0x3e, 0x00, 0x16, 0x30,
+  0x14, 0x01, 0x00, 0x00, 0x0f, 0xac, 0x04, 0x01, 0x00, 0x00, 0x0f, 0xac,
+  0x04, 0x01, 0x00, 0x00, 0x0f, 0xac, 0x02, 0x80, 0x00
+};
+
+uint8_t eapol3[] = {
+  0x08, 0x02, 0x3a, 0x01, 0x82, 0x3e, 0x7a, 0x30, 0x6c, 0xa8, 0x64, 0x66,
+  0xb3, 0xce, 0x22, 0xa3, 0x64, 0x66, 0xb3, 0xce, 0x22, 0xa3, 0x10, 0x00,
+  0xaa, 0xaa, 0x03, 0x00, 0x00, 0x00, 0x88, 0x8e, 0x02, 0x03, 0x00, 0x97,
+  0x02, 0x13, 0xca, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x02, 0x3b, 0x75, 0xe7, 0x7e, 0x43, 0x52, 0x48, 0xa5, 0x8d, 0x20, 0x70,
+  0xb0, 0x22, 0xc5, 0x49, 0xeb, 0xf3, 0x45, 0x74, 0x78, 0xef, 0x38, 0x3a,
+  0xf0, 0x11, 0x64, 0x2e, 0xa6, 0xd7, 0xa9, 0xbe, 0xcc, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x95, 0xba, 0x3c, 0xcb, 0xac, 0x58, 0x4a,
+  0x25, 0xa6, 0xa1, 0xc8, 0x03, 0xa7, 0x39, 0xdf, 0x0f, 0x00, 0x38, 0xc5,
+  0x7e, 0xae, 0xd5, 0xe3, 0x6e, 0xa1, 0x8a, 0x90, 0x3e, 0xc2, 0x7c, 0x6c,
+  0xb4, 0xe9, 0xa7, 0x2b, 0x9e, 0xb2, 0x7d, 0xf8, 0x55, 0x0a, 0xb4, 0x89,
+  0x2b, 0x38, 0x1e, 0xc1, 0x81, 0x0d, 0x96, 0x6c, 0x60, 0xe7, 0x8d, 0x84,
+  0x80, 0x9e, 0xad, 0xc8, 0xe0, 0xe9, 0xec, 0x88, 0x14, 0xba, 0x69, 0x9d,
+  0xb7, 0x3b, 0x0b, 0x10, 0xc8, 0x74, 0xc9
+};
+
+uint8_t eapol4[] = {
+  0x08, 0x01, 0x3a, 0x01, 0x64, 0x66, 0xb3, 0xce, 0x22, 0xa3, 0x82, 0x3e,
+  0x7a, 0x30, 0x6c, 0xa8, 0x64, 0x66, 0xb3, 0xce, 0x22, 0xa3, 0x40, 0x00,
+  0xaa, 0xaa, 0x03, 0x00, 0x00, 0x00, 0x88, 0x8e, 0x01, 0x03, 0x00, 0x5f,
+  0x02, 0x03, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x65, 0xb4, 0x07, 0x2f, 0xfc, 0x75, 0xfe,
+  0x32, 0xa1, 0xda, 0xad, 0x68, 0x9c, 0xf5, 0xe3, 0xa6, 0x00, 0x00
+};
+
+uint8_t auth1[] = {
+  0xb0, 0x00, 0x3c, 0x00, 0x64, 0x66, 0xb3, 0xce, 0x22, 0xa4, 0x62, 0x18,
+  0xa0, 0x2e, 0x53, 0x0e, 0x64, 0x66, 0xb3, 0xce, 0x22, 0xa4, 0x40, 0x8d,
+  0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0xdd, 0x09, 0x00, 0x10, 0x18, 0x02,
+  0x00, 0x00, 0x10, 0x00, 0x00
+};
+
+uint8_t auth2[] = {
+  0xb0, 0x00, 0x3c, 0x00, 0x62, 0x18, 0xa0, 0x2e, 0x53, 0x0e, 0x64, 0x66,
+  0xb3, 0xce, 0x22, 0xa4, 0x64, 0x66, 0xb3, 0xce, 0x22, 0xa4, 0x80, 0x04,
+  0x00, 0x00, 0x02, 0x00, 0x00, 0x00
+};
+
+uint8_t assoc1[] = {
+  0x00, 0x00, 0x3c, 0x00, 0x64, 0x66, 0xb3, 0xce, 0x22, 0xa4, 0x62, 0x18,
+  0xa0, 0x2e, 0x53, 0x0e, 0x64, 0x66, 0xb3, 0xce, 0x22, 0xa4, 0x50, 0x8d,
+  0x11, 0x00, 0x0a, 0x00, 0x00, 0x04, 0x54, 0x53, 0x54, 0x35, 0x01, 0x08,
+  0x8c, 0x12, 0x98, 0x24, 0xb0, 0x48, 0x60, 0x6c, 0x21, 0x02, 0x0a, 0x11,
+  0x24, 0x0a, 0x24, 0x04, 0x34, 0x04, 0x64, 0x0c, 0x95, 0x04, 0xa5, 0x01,
+  0x30, 0x14, 0x01, 0x00, 0x00, 0x0f, 0xac, 0x04, 0x01, 0x00, 0x00, 0x0f,
+  0xac, 0x04, 0x01, 0x00, 0x00, 0x0f, 0xac, 0x02, 0x80, 0x00, 0x3b, 0x15,
+  0x73, 0x70, 0x73, 0x74, 0x75, 0x7c, 0x7d, 0x7e, 0x7f, 0x80, 0x81, 0x82,
+  0x76, 0x77, 0x78, 0x79, 0x7a, 0x7b, 0x51, 0x53, 0x54, 0x2d, 0x1a, 0x6f,
+  0x00, 0x1b, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x7f, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00,
+  0x20, 0xdd, 0x09, 0x00, 0x10, 0x18, 0x02, 0x00, 0x00, 0x10, 0x00, 0x00,
+  0xdd, 0x07, 0x00, 0x50, 0xf2, 0x02, 0x00, 0x01, 0x00
+};
+
+uint8_t assoc2[] = {
+  0x10, 0x00, 0x3c, 0x00, 0x62, 0x18, 0xa0, 0x2e, 0x53, 0x0e, 0x64, 0x66,
+  0xb3, 0xce, 0x22, 0xa4, 0x64, 0x66, 0xb3, 0xce, 0x22, 0xa4, 0x90, 0x04,
+  0x11, 0x00, 0x00, 0x00, 0x01, 0xc0, 0x01, 0x08, 0x8c, 0x12, 0x98, 0x24,
+  0xb0, 0x48, 0x60, 0x6c, 0x2d, 0x1a, 0xed, 0x01, 0x1b, 0xff, 0xff, 0xff,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x3d, 0x16, 0x28, 0x00,
+  0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7f, 0x08, 0x04, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0xdd, 0x18, 0x00, 0x50, 0xf2, 0x02,
+  0x01, 0x01, 0x80, 0x00, 0x03, 0xa4, 0x00, 0x00, 0x27, 0xa4, 0x00, 0x00,
+  0x42, 0x43, 0x5e, 0x00, 0x62, 0x32, 0x2f, 0x00
+};
+
+uint8_t eapol1qos[] ={
+  0x88, 0x02, 0x3c, 0x00, 0x62, 0x18, 0xa0, 0x2e, 0x53, 0x0e, 0x64, 0x66,
+  0xb3, 0xce, 0x22, 0xa4, 0x64, 0x66, 0xb3, 0xce, 0x22, 0xa4, 0x00, 0x00,
+  0x07, 0x00, 0xaa, 0xaa, 0x03, 0x00, 0x00, 0x00, 0x88, 0x8e, 0x02, 0x03,
+  0x00, 0x5f, 0x02, 0x00, 0x8a, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x01, 0xfb, 0x69, 0x71, 0x3f, 0xf4, 0xd1, 0x4f, 0x2b, 0x62,
+  0xe5, 0xfa, 0x54, 0x79, 0x31, 0xfb, 0x71, 0x9a, 0x41, 0x5b, 0x5a, 0xc9,
+  0x1a, 0xc9, 0x90, 0x6d, 0x74, 0xe2, 0xa9, 0x71, 0xef, 0x9b, 0x03, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00
+};
+
+static int orig_call = 0;
+
+int
+wlc_ioctl_orig(struct wlc_info *wlc, int cmd, char *arg, int len, void *wlc_if)
+{
+    orig_call = 1;
+    return wlc_ioctl(wlc, cmd, arg, len, wlc_if);
+}
+
+typedef struct {
+    char        *buf;
+    uint32_t    buf_size;
+    uint32_t    idx;
+} hndrte_log_t;
+
+extern hndrte_log_t active_log;
+
+int
+wlc_ioctl_hook(struct wlc_info *wlc, int cmd, char *arg, int len, void *wlc_if)
+{
+    void *lr;
+    __asm("mov %0, lr" : "=r" (lr));
+
+    int ret = IOCTL_ERROR;
+    argprintf_init(arg, len);
+
+    switch (cmd) {
+        case NEX_INJECT_FRAME:
+            {
+                sk_buff *p;
+                int bytes_used = 0;
+                struct inject_frame *frm = (struct inject_frame *) arg;
+
+                while ((frm->hdr.len > 0) && (bytes_used + frm->hdr.len <= len)) {
+                    // add a dummy radiotap header if frame does not contain one
+                    if (frm->hdr.type == 0) {
+                        p = pkt_buf_get_skb(wlc->osh, frm->hdr.len + TXOFF + sizeof(struct ieee80211_radiotap_header) - sizeof(frm->hdr));
+                        if (p == 0) {
+                            break;
+                        }
+                        skb_pull(p, TXOFF);
+                        struct ieee80211_radiotap_header *radiotap = 
+                            (struct ieee80211_radiotap_header *) p->data;
+                        
+                        memset(radiotap, 0, sizeof(struct ieee80211_radiotap_header));
+                        
+                        radiotap->it_len = sizeof(struct ieee80211_radiotap_header);
+                        
+                        skb_pull(p, sizeof(struct ieee80211_radiotap_header));
+                        memcpy(p->data, frm->data, frm->hdr.len - sizeof(frm->hdr));
+                        skb_push(p, sizeof(struct ieee80211_radiotap_header));
+                    } else {
+                        p = pkt_buf_get_skb(wlc->osh, frm->hdr.len + TXOFF - sizeof(frm->hdr));
+                        if (p == 0) {
+                            break;
+                        }
+                        skb_pull(p, TXOFF);
+
+                        memcpy(p->data, frm->data, frm->hdr.len - sizeof(frm->hdr));
+                    }
+
+                    inject_frame(wlc, p);
+
+                    bytes_used += frm->hdr.len;
+
+                    frm = (struct inject_frame *) (arg + bytes_used);
+                }
+
+                ret = IOCTL_SUCCESS;
+            }
+            break;
+
+        case WLC_GET_MONITOR:
+        {
+            struct wlc_info *wlc2 = (struct wlc_info*) get_other_wlc(wlc);
+            uint32_t mon = 0;
+            wlc_ioctl_orig(wlc2, WLC_GET_MONITOR, (char *) &mon, sizeof(mon), wlc_if);
+            wlc_ioctl_orig(wlc, WLC_GET_MONITOR, arg, len, wlc_if);
+            
+            *(uint32_t *) arg |= mon;
+
+            ret = IOCTL_SUCCESS;
+            break;
+        }
+
+        case WLC_SET_MONITOR:
+        case 0x613:
+        {
+            unsigned short chanspec = get_chanspec(wlc);
+            struct wlc_info *wlc_for_chanspec = (struct wlc_info *) find_wlc_for_chanspec(wlc, 0, chanspec, 0, 0);
+            struct wlc_info *wlc_other = (struct wlc_info*) get_other_wlc(wlc_for_chanspec);
+
+            wlc_other->pub->tunables->copycount = 17;
+            path_to_wl_set_monitor(wlc_other, 0);
+            
+            if (*(uint32_t *) arg == 0) {
+                wlc_for_chanspec->pub->tunables->copycount = 17;
+            } else {
+                wlc_for_chanspec->pub->tunables->copycount = 2;
+            }
+            path_to_wl_set_monitor(wlc_for_chanspec, *(uint32_t *) arg);
+
+            ret = IOCTL_SUCCESS;
+
+            break;
+        }
+
+        case WLC_SET_VAR:
+        {
+#if 0
+            if (!strncmp(arg, "chanspec", 8)) {
+                set_chanspec(wlc, 0xd028);
+                ret = IOCTL_SUCCESS;
+            } else {
+#endif
+                ret = wlc_ioctl_orig(wlc, WLC_SET_VAR, arg, len, wlc_if);
+#if 0
+            }
+#endif
+            break;
+        }
+
+        case 0x600:
+        {
+            argprintf("%s\n%s\n%s\n", version, date, time);
+
+            ret = IOCTL_SUCCESS;
+            break;
+        }
+
+        case 0x609: // return console
+        {
+            if (len > active_log.buf_size) len = active_log.buf_size;
+            if (active_log.idx >= len) {
+                memcpy(arg, &active_log.buf[active_log.idx - len], len);
+            } else {
+                memcpy(&arg[len - active_log.idx], active_log.buf, active_log.idx);
+                memcpy(arg, &active_log.buf[active_log.buf_size - (len - active_log.idx)], len - active_log.idx);
+            }
+            ret = IOCTL_SUCCESS;
+            break;
+        }
+
+        case 0x621:
+        {
+            struct sk_buff *p;
+            p = pkt_buf_get_skb(wlc->osh, sizeof(eapol1) + TXOFF + sizeof(struct ieee80211_radiotap_header));
+            if (p == 0) {
+                break;
+            }
+            skb_pull(p, TXOFF);
+            struct ieee80211_radiotap_header *radiotap = 
+                (struct ieee80211_radiotap_header *) p->data;
+            
+            memset(radiotap, 0, sizeof(struct ieee80211_radiotap_header));
+            
+            radiotap->it_len = sizeof(struct ieee80211_radiotap_header);
+            
+            skb_pull(p, sizeof(struct ieee80211_radiotap_header));
+            memcpy(p->data, eapol1, sizeof(eapol1));
+            skb_push(p, sizeof(struct ieee80211_radiotap_header));
+
+            inject_frame(wlc, p);
+            ret = IOCTL_SUCCESS;
+            break;
+        }
+
+        case 0x622:
+        {
+            struct sk_buff *p;
+            p = pkt_buf_get_skb(wlc->osh, sizeof(eapol2) + TXOFF + sizeof(struct ieee80211_radiotap_header));
+            if (p == 0) {
+                break;
+            }
+            skb_pull(p, TXOFF);
+            struct ieee80211_radiotap_header *radiotap = 
+                (struct ieee80211_radiotap_header *) p->data;
+            
+            memset(radiotap, 0, sizeof(struct ieee80211_radiotap_header));
+            
+            radiotap->it_len = sizeof(struct ieee80211_radiotap_header);
+            
+            skb_pull(p, sizeof(struct ieee80211_radiotap_header));
+            memcpy(p->data, eapol2, sizeof(eapol2));
+            skb_push(p, sizeof(struct ieee80211_radiotap_header));
+
+            inject_frame(wlc, p);
+            ret = IOCTL_SUCCESS;
+            break;
+        }
+
+        case 0x623:
+        {
+            struct sk_buff *p;
+            p = pkt_buf_get_skb(wlc->osh, sizeof(eapol3) + TXOFF + sizeof(struct ieee80211_radiotap_header));
+            if (p == 0) {
+                break;
+            }
+            skb_pull(p, TXOFF);
+            struct ieee80211_radiotap_header *radiotap = 
+                (struct ieee80211_radiotap_header *) p->data;
+            
+            memset(radiotap, 0, sizeof(struct ieee80211_radiotap_header));
+            
+            radiotap->it_len = sizeof(struct ieee80211_radiotap_header);
+            
+            skb_pull(p, sizeof(struct ieee80211_radiotap_header));
+            memcpy(p->data, eapol3, sizeof(eapol3));
+            skb_push(p, sizeof(struct ieee80211_radiotap_header));
+
+            inject_frame(wlc, p);
+            ret = IOCTL_SUCCESS;
+            break;
+        }
+
+        case 0x624:
+        {
+            struct sk_buff *p;
+            p = pkt_buf_get_skb(wlc->osh, sizeof(eapol4) + TXOFF + sizeof(struct ieee80211_radiotap_header));
+            if (p == 0) {
+                break;
+            }
+            skb_pull(p, TXOFF);
+            struct ieee80211_radiotap_header *radiotap = 
+                (struct ieee80211_radiotap_header *) p->data;
+            
+            memset(radiotap, 0, sizeof(struct ieee80211_radiotap_header));
+            
+            radiotap->it_len = sizeof(struct ieee80211_radiotap_header);
+            
+            skb_pull(p, sizeof(struct ieee80211_radiotap_header));
+            memcpy(p->data, eapol4, sizeof(eapol4));
+            skb_push(p, sizeof(struct ieee80211_radiotap_header));
+
+            inject_frame(wlc, p);
+            ret = IOCTL_SUCCESS;
+            break;
+        }
+
+        case 0x625:
+        {
+            struct sk_buff *p;
+            p = pkt_buf_get_skb(wlc->osh, sizeof(auth1) + TXOFF + sizeof(struct ieee80211_radiotap_header));
+            if (p == 0) {
+                break;
+            }
+            skb_pull(p, TXOFF);
+            struct ieee80211_radiotap_header *radiotap = 
+                (struct ieee80211_radiotap_header *) p->data;
+            
+            memset(radiotap, 0, sizeof(struct ieee80211_radiotap_header));
+            
+            radiotap->it_len = sizeof(struct ieee80211_radiotap_header);
+            
+            skb_pull(p, sizeof(struct ieee80211_radiotap_header));
+            memcpy(p->data, auth1, sizeof(auth1));
+            skb_push(p, sizeof(struct ieee80211_radiotap_header));
+
+            inject_frame(wlc, p);
+            ret = IOCTL_SUCCESS;
+            break;
+        }
+
+        case 0x626:
+        {
+            struct sk_buff *p;
+            p = pkt_buf_get_skb(wlc->osh, sizeof(auth2) + TXOFF + sizeof(struct ieee80211_radiotap_header));
+            if (p == 0) {
+                break;
+            }
+            skb_pull(p, TXOFF);
+            struct ieee80211_radiotap_header *radiotap = 
+                (struct ieee80211_radiotap_header *) p->data;
+            
+            memset(radiotap, 0, sizeof(struct ieee80211_radiotap_header));
+            
+            radiotap->it_len = sizeof(struct ieee80211_radiotap_header);
+            
+            skb_pull(p, sizeof(struct ieee80211_radiotap_header));
+            memcpy(p->data, auth2, sizeof(auth2));
+            skb_push(p, sizeof(struct ieee80211_radiotap_header));
+
+            inject_frame(wlc, p);
+            ret = IOCTL_SUCCESS;
+            break;
+        }
+
+        case 0x627:
+        {
+            struct sk_buff *p;
+            p = pkt_buf_get_skb(wlc->osh, sizeof(assoc1) + TXOFF + sizeof(struct ieee80211_radiotap_header));
+            if (p == 0) {
+                break;
+            }
+            skb_pull(p, TXOFF);
+            struct ieee80211_radiotap_header *radiotap = 
+                (struct ieee80211_radiotap_header *) p->data;
+            
+            memset(radiotap, 0, sizeof(struct ieee80211_radiotap_header));
+            
+            radiotap->it_len = sizeof(struct ieee80211_radiotap_header);
+            
+            skb_pull(p, sizeof(struct ieee80211_radiotap_header));
+            memcpy(p->data, assoc1, sizeof(assoc1));
+            skb_push(p, sizeof(struct ieee80211_radiotap_header));
+
+            inject_frame(wlc, p);
+            ret = IOCTL_SUCCESS;
+            break;
+        }
+
+        case 0x628:
+        {
+            struct sk_buff *p;
+            p = pkt_buf_get_skb(wlc->osh, sizeof(assoc2) + TXOFF + sizeof(struct ieee80211_radiotap_header));
+            if (p == 0) {
+                break;
+            }
+            skb_pull(p, TXOFF);
+            struct ieee80211_radiotap_header *radiotap = 
+                (struct ieee80211_radiotap_header *) p->data;
+            
+            memset(radiotap, 0, sizeof(struct ieee80211_radiotap_header));
+            
+            radiotap->it_len = sizeof(struct ieee80211_radiotap_header);
+            
+            skb_pull(p, sizeof(struct ieee80211_radiotap_header));
+            memcpy(p->data, assoc2, sizeof(assoc2));
+            skb_push(p, sizeof(struct ieee80211_radiotap_header));
+
+            inject_frame(wlc, p);
+            ret = IOCTL_SUCCESS;
+            break;
+        }
+
+        case 0x629:
+        {
+            struct sk_buff *p;
+            p = pkt_buf_get_skb(wlc->osh, sizeof(eapol1qos) + TXOFF + sizeof(struct ieee80211_radiotap_header));
+            if (p == 0) {
+                break;
+            }
+            skb_pull(p, TXOFF);
+            struct ieee80211_radiotap_header *radiotap = 
+                (struct ieee80211_radiotap_header *) p->data;
+            
+            memset(radiotap, 0, sizeof(struct ieee80211_radiotap_header));
+            
+            radiotap->it_len = sizeof(struct ieee80211_radiotap_header);
+            
+            skb_pull(p, sizeof(struct ieee80211_radiotap_header));
+            memcpy(p->data, eapol1qos, sizeof(eapol1qos));
+            skb_push(p, sizeof(struct ieee80211_radiotap_header));
+
+            inject_frame(wlc, p);
+            ret = IOCTL_SUCCESS;
+            break;
+        }
+
+        default:
+            ret = wlc_ioctl_orig(wlc, cmd, arg, len, wlc_if);
+    }
+
+    return ret;
+}
+
+int
+called_by_wlc_ioctl_hook2(struct wlc_info *wlc, int cmd, char *arg, int len, void *wlc_if)
+{
+    int ret = IOCTL_ERROR;
+
+    if (orig_call == 1) {
+        ret = called_by_wlc_ioctl(wlc, cmd, arg, len);
+        orig_call = 0;
+    } else {
+        ret = wlc_ioctl_hook(wlc, cmd, arg, len, wlc_if);
+        if (ret == IOCTL_SUCCESS)
+            ret = 1; // otherwise the original wlc_ioctl processing will be done
+    }
+
+    return ret;
+}
+
+int
+called_by_wlc_ioctl_hook(struct wlc_info *wlc, int cmd, char *arg, int len)
+{
+    void *wlc_if;
+
+    __asm("mov %0, r9" : "=r" (wlc_if));
+
+    return called_by_wlc_ioctl_hook2(wlc, cmd, arg, len, wlc_if);
+}
+
+__attribute__((at(0x1819A0, "", CHIP_VER_ALL, FW_VER_ALL)))
+GenericPatch4(called_by_wlc_ioctl_hook, called_by_wlc_ioctl_hook + 1);

--- a/patches/bcm4375b1/18_41_117_sta/nexmon/src/local_wrapper.c
+++ b/patches/bcm4375b1/18_41_117_sta/nexmon/src/local_wrapper.c
@@ -1,0 +1,218 @@
+/***************************************************************************
+ *                                                                         *
+ *          ###########   ###########   ##########    ##########           *
+ *         ############  ############  ############  ############          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ###########   ####  ######  ##   ##   ##  ##    ######          *
+ *          ###########  ####  #       ##   ##   ##  ##    #    #          *
+ *                   ##  ##    ######  ##   ##   ##  ##    #    #          *
+ *                   ##  ##    #       ##   ##   ##  ##    #    #          *
+ *         ############  ##### ######  ##   ##   ##  ##### ######          *
+ *         ###########    ###########  ##   ##   ##   ##########           *
+ *                                                                         *
+ *            S E C U R E   M O B I L E   N E T W O R K I N G              *
+ *                                                                         *
+ * This file is part of NexMon.                                            *
+ *                                                                         *
+ * Copyright (c) 2016 NexMon Team                                          *
+ *                                                                         *
+ * NexMon is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by    *
+ * the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                     *
+ *                                                                         *
+ * NexMon is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of          *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
+ * GNU General Public License for more details.                            *
+ *                                                                         *
+ * You should have received a copy of the GNU General Public License       *
+ * along with NexMon. If not, see <http://www.gnu.org/licenses/>.          *
+ *                                                                         *
+ **************************************************************************/
+
+#ifndef LOCAL_WRAPPER_C
+#define LOCAL_WRAPPER_C
+
+#include <firmware_version.h>
+#include <structs.h>
+#include <stdarg.h>
+
+#ifndef LOCAL_WRAPPER_H
+    // if this file is not included in the local_wrapper.h file, create dummy functions
+    #define VOID_DUMMY { ; }
+    #define RETURN_DUMMY { ; return 0; }
+
+    #define AT(CHIPVER, FWVER, ADDR) __attribute__((weak, at(ADDR, "dummy", CHIPVER, FWVER)))
+#else
+    // if this file is included in the wrapper.h file, create prototypes
+    #define VOID_DUMMY ;
+    #define RETURN_DUMMY ;
+    #define AT(CHIPVER, FWVER, ADDR)
+#endif
+
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_8_9_sta, 0x1FD9BC)
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_117_sta, 0x2020E8)
+int
+called_by_wlc_ioctl(struct wlc_info *wlc, int cmd, char *arg, int len)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_18_38_18_sta, 0x21803E)
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_8_9_sta, 0x232E0E)
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_117_sta, 0x23A9BE)
+void *
+path_to_path_to_indirect_call_of_phy_ac_rssi_compute(void *rssi_related, void *wrxh, void *a3)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_ALL, 0xC4160)
+int
+wlc_ioctl(void *wlc, int cmd, void *arg, int len, void *wlc_if)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_ALL, 0xC4168)
+int
+wlc_ioctl_plus8(void *wlc, int cmd, void *arg, int len, void *wlc_if)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_18_38_18_sta, 0x217010)
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_8_9_sta, 0x231DE0)
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_117_sta, 0x2398C4)
+void *
+wlc_recv(void *wlc, void *p)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_18_38_18_sta, 0x183834)
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_8_9_sta, 0x1845A0)
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_117_sta, 0x1845FC)
+int
+memcpy(void *dst, void *src, int len)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_ALL, 0xC48F0)
+int
+wlc_iovar_op(void *wlc, char *varname, void *params, int p_len, void *arg, int len, char set, void *wlcif)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_18_38_18_sta, 0x1863A0)
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_8_9_sta, 0x1876A8)
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_117_sta, 0x186E58)
+void *
+pkt_buf_get_skb(void *osh, unsigned int len)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_18_38_18_sta, 0x1863F0)
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_8_9_sta, 0x187718)
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_117_sta, 0x186EC8)
+void *
+pkt_buf_free_skb(void *osh, void *p, int send)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_18_38_18_sta, 0x1C7DF0)
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_8_9_sta, 0x1D5CBC)
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_117_sta, 0x1D8224)
+void
+wl_set_copycount_bytes(void *wl, int copycount, int d11rxoffset)
+VOID_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_ALL, 0x8AAC)
+int
+snprintf(char *buf, unsigned int n, const char *format, ...)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_ALL, 0x8C08)
+int
+vsnprintf(char *buf, unsigned int n, const char *format, va_list ap)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_ALL, 0x8988)
+void *
+memset(void *dst, int value, int len)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_18_38_18_sta, 0x255A80)
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_8_9_sta, 0x271C00)
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_117_sta, 0x279070)
+void *
+wlc_okc_attach(void *wlc)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_ALL, 0x61304)
+void *
+osl_mallocz(int size)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_18_38_18_sta, 0x24B894)
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_8_9_sta, 0x267594)
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_117_sta, 0x26EC84)
+void
+wlc_tunables_init(void *tunables, void *pub_cmn, int a3, int a4)
+VOID_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_ALL, 0x142D10)
+unsigned int
+hndrte_time_ms()
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_ALL, 0x143AC0)
+void
+pktfrag_trim_tailbytes(void * osh, void* p, unsigned short len, unsigned char type)
+VOID_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_ALL, 0x1428C0)
+void
+wl_sendup_4param(void *wl, void *wlif, void *p, int numpkt)
+VOID_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_ALL, 0x7861C)
+void
+wlc_recover_tsf64(void *wlc, void *wrxh, unsigned int *tsf_h, unsigned int *tsf_l)
+VOID_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_ALL, 0x5B928)
+char
+phy_noise_avg(void *pih)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_ALL, 0xA068)
+unsigned char
+wf_chspec_ctlchan(unsigned short chspec)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_ALL, 0x9DA4)
+int
+wf_channel2mhz(unsigned int ch, unsigned int start_factor)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_ALL, 0x8B6C)
+int
+strncmp(char *str1, char *str2, unsigned int num)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_ALL, 0xFFBA4)
+void *
+get_other_wlc(void *wlc)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_ALL, 0x144A60)
+void *
+find_wlc_for_chanspec(void *wlc, void *bi, unsigned short chanspec, void *skip_wlc, unsigned int match_mask)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_ALL, 0x79EB0)
+int
+path_to_wl_set_monitor(void *wlc, int value)
+RETURN_DUMMY
+
+AT(CHIP_VER_BCM4375b1, FW_VER_18_38_18_sta, 0x1C9B34)
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_8_9_sta, 0x1D7CF8)
+AT(CHIP_VER_BCM4375b1, FW_VER_18_41_117_sta, 0x1D9E70)
+int
+wlc_sendctl(void *wlc, void *p, void *qi, void *scb, unsigned int fifo, unsigned int rate_override, char enq_only)
+RETURN_DUMMY
+
+#undef VOID_DUMMY
+#undef RETURN_DUMMY
+#undef AT
+
+#endif /*LOCAL_WRAPPER_C*/

--- a/patches/bcm4375b1/18_41_117_sta/nexmon/src/monitormode.c
+++ b/patches/bcm4375b1/18_41_117_sta/nexmon/src/monitormode.c
@@ -1,0 +1,248 @@
+/***************************************************************************
+ *                                                                         *
+ *          ###########   ###########   ##########    ##########           *
+ *         ############  ############  ############  ############          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ###########   ####  ######  ##   ##   ##  ##    ######          *
+ *          ###########  ####  #       ##   ##   ##  ##    #    #          *
+ *                   ##  ##    ######  ##   ##   ##  ##    #    #          *
+ *                   ##  ##    #       ##   ##   ##  ##    #    #          *
+ *         ############  ##### ######  ##   ##   ##  ##### ######          *
+ *         ###########    ###########  ##   ##   ##   ##########           *
+ *                                                                         *
+ *            S E C U R E   M O B I L E   N E T W O R K I N G              *
+ *                                                                         *
+ * This file is part of NexMon.                                            *
+ *                                                                         *
+ * Copyright (c) 2016 NexMon Team                                          *
+ *                                                                         *
+ * NexMon is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by    *
+ * the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                     *
+ *                                                                         *
+ * NexMon is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of          *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
+ * GNU General Public License for more details.                            *
+ *                                                                         *
+ * You should have received a copy of the GNU General Public License       *
+ * along with NexMon. If not, see <http://www.gnu.org/licenses/>.          *
+ *                                                                         *
+ **************************************************************************/
+
+#pragma NEXMON targetregion "patch"
+
+#include <firmware_version.h>   // definition of firmware version macros
+#include <debug.h>              // contains macros to access the debug hardware
+#include <wrapper.h>            // wrapper definitions for functions that already exist in the firmware
+#include <structs.h>            // structures that are used by the code in the firmware
+#include <helper.h>             // useful helper functions
+#include <patcher.h>            // macros used to craete patches such as BLPatch, BPatch, ...
+#include <rates.h>              // rates used to build the ratespec for frame injection
+#include <ieee80211_radiotap.h>
+#include <bcmwifi_channels.h>
+#include <local_wrapper.h>
+
+#define RXS_SHORT_MASK      0x01
+#define RXS_PBPRES          (1 << 2)
+#define RXSS_PBPRES         (1 << 3)
+#define PLCP_LEN            6
+
+struct d11rxhdr {
+    uint16 RxFrameSize;     // 0x00
+    uint8 dma_flags;        // 0x02
+    uint8 fifo;             // 0x03
+    uint16 PhyRxStatus_0;   // 0x04
+    uint16 PhyRxStatus_1;   // 0x06
+    uint16 PhyRxStatus_2;   // 0x08
+    uint16 PhyRxStatus_3;   // 0x0A
+    uint16 PhyRxStatus_4;   // 0x0C
+    uint16 PhyRxStatus_5;   // 0x0E
+    uint16 RxStatus1;       // 0x10
+    uint16 RxStatus2;       // 0x12
+    uint16 RxTSFTime;       // 0x14
+    uint16 RxChan;          // 0x16
+    uint16 RxFrameSize_0;   // 0x18 somehow this seems to be the RxChan
+    uint16 HdrConvSt;       // 0x1A
+    uint16 AvbRxTimeL;      // 0x1C
+    uint16 AvbRxTimeH;      // 0x1E somehow this seems to fit
+    uint16 MuRate;          // 0x20
+    uint16 errflags;        // 0x22
+} __attribute__((packed));
+
+
+struct wlc_d11rxhdr {
+    uint32 tsf_l;
+    int8 rssi;
+    int8 rssi_qdb;
+    uint8 pad[2];
+    int8 rxpwr[4];
+    struct d11rxhdr rxhdr;
+} __attribute__((packed));
+
+struct myradiotaphdr {
+    struct ieee80211_radiotap_header rtap;
+    struct tsf tsf;
+    unsigned short chan_freq;
+    unsigned short chan_flags;
+    char dbm_antsignal;
+    char dbm_antnoise;
+    uint16_t PAD;
+    struct xchan xchan;
+} __attribute__((packed));
+
+struct wlc_monitor_info *
+wlc_monitor_attach(struct wlc_info *wlc) {
+    struct wlc_monitor_info *mon_info = (struct wlc_monitor_info *) osl_mallocz(32);
+    if (!mon_info) return 0;
+    mon_info->buf_32bytes = osl_mallocz(32);
+    if (!mon_info->buf_32bytes) return 0;
+    mon_info->buf_12bytes = (struct wlc_monitor_info *) osl_mallocz(12);
+    if (!mon_info->buf_12bytes) return 0;
+
+    mon_info->wlc = wlc;
+    mon_info->promisc_bits = 0;
+    mon_info->timer_active = 0;
+    mon_info->mon_cal_timer = 0; // should be set to a timer
+    mon_info->chanspec = 0;
+
+    return mon_info;
+}
+
+void *
+wlc_okc_attach_hook(struct wlc_info *wlc) {
+    struct wlc_monitor_info *mon_info = wlc_monitor_attach(wlc);
+    if (mon_info) {
+        wlc->mon_info = mon_info;
+        wlc->pub->_mon = 1;
+    }
+
+    return wlc_okc_attach(wlc);
+}
+
+int
+path_to_path_to_indirect_call_of_phy_ac_rssi_compute_hook2(void *rssi_related, struct wlc_d11rxhdr *wrxh, void *a3, struct sk_buff *p, struct wlc_info *wlc) {
+    path_to_path_to_indirect_call_of_phy_ac_rssi_compute(rssi_related, wrxh, a3);
+
+    if (wlc->monitor == 2) {
+        struct osl_info *osh = wlc->osh;
+        struct wl_info *wl = wlc->wl;
+        struct d11rxhdr *rxh = &wrxh->rxhdr;
+        uint32_t isamsdu = (rxh->PhyRxStatus_0 & 1) != 0;
+        int len = p->len;
+
+        if (!isamsdu)
+            pktfrag_trim_tailbytes(osh, p, 4, 1);
+
+        int additional_padding = 0;
+
+        if (p->len == 6) {
+            skb_pull(p, 6);
+
+            p->frag_used_len += 4;
+            additional_padding = 4;
+        } else if (p->len == 8) {
+            skb_pull(p, 8);
+
+            p->frag_used_len += 4;
+            additional_padding = 2;
+        } else {
+            additional_padding = 6;
+        }
+
+        skb_push(p, sizeof(struct myradiotaphdr));
+
+        struct myradiotaphdr *myrtap = (struct myradiotaphdr *) p->data;
+        memset(myrtap, 0, sizeof(struct myradiotaphdr));
+
+        myrtap->rtap.it_version = 0;
+        myrtap->rtap.it_pad = len;
+        myrtap->rtap.it_len = sizeof(struct myradiotaphdr) + additional_padding;
+
+        myrtap->rtap.it_present = 
+          (1<<IEEE80211_RADIOTAP_TSFT)
+        | (1<<IEEE80211_RADIOTAP_CHANNEL)
+        | (1<<IEEE80211_RADIOTAP_DBM_ANTSIGNAL)
+        | (1<<IEEE80211_RADIOTAP_DBM_ANTNOISE)
+        | (1<<IEEE80211_RADIOTAP_XCHANNEL);
+
+        uint16_t chanspec = rxh->RxFrameSize_0;
+        if (CHSPEC_IS2G(chanspec)) {
+            myrtap->chan_flags = IEEE80211_CHAN_2GHZ | IEEE80211_CHAN_DYN;
+            myrtap->chan_freq = wf_channel2mhz(wf_chspec_ctlchan(chanspec), WF_CHAN_FACTOR_2_4_G);
+        } else {
+            myrtap->chan_flags = IEEE80211_CHAN_5GHZ | IEEE80211_CHAN_OFDM;
+            myrtap->chan_freq = wf_channel2mhz(wf_chspec_ctlchan(chanspec), WF_CHAN_FACTOR_5_G);
+        }
+
+        wlc_recover_tsf64(wlc, wrxh, &myrtap->tsf.tsf_h, &myrtap->tsf.tsf_l);
+        myrtap->tsf.tsf_h = 0;
+
+        myrtap->dbm_antsignal = wrxh->rssi;
+        myrtap->dbm_antnoise = phy_noise_avg(wlc->pi);
+
+        myrtap->xchan.xchannel_flags = myrtap->chan_flags;
+        if (CHSPEC_IS40(chanspec)) {
+            if (CHSPEC_SB_UPPER(chanspec)) {
+                myrtap->xchan.xchannel_flags |= IEEE80211_CHAN_HT40D;
+            } else {
+                myrtap->xchan.xchannel_flags |= IEEE80211_CHAN_HT40U;
+            }
+        } else {
+            myrtap->xchan.xchannel_flags |= IEEE80211_CHAN_HT20;
+        }
+
+        myrtap->xchan.xchannel_freq = myrtap->chan_freq;
+        myrtap->xchan.xchannel_channel = wf_chspec_ctlchan(chanspec);
+        myrtap->xchan.xchannel_maxpower = (17*2);
+
+        wl->dev->chained->funcs->xmit(wl->dev, wl->dev->chained, p);
+    }
+
+    return wlc->monitor;
+}
+
+int
+path_to_path_to_indirect_call_of_phy_ac_rssi_compute_hook(void *rssi_related, struct wlc_d11rxhdr *wrxh, void *a3) {
+    struct sk_buff *p;
+    struct wlc_info *wlc;
+
+    __asm("mov %0, r4" : "=r" (p));
+    __asm("mov %0, r5" : "=r" (wlc));
+
+    return path_to_path_to_indirect_call_of_phy_ac_rssi_compute_hook2(rssi_related, wrxh, a3, p, wlc);
+}
+
+__attribute__((at(0x23998E, "", CHIP_VER_BCM4375b1, FW_VER_18_41_117_sta)))
+__attribute__((at(0x231EAA, "", CHIP_VER_BCM4375b1, FW_VER_18_41_8_9_sta)))
+__attribute__((at(0x2170DA, "", CHIP_VER_BCM4375b1, FW_VER_18_38_18_sta)))
+BLPatch(path_to_path_to_indirect_call_of_phy_ac_rssi_compute_hook, path_to_path_to_indirect_call_of_phy_ac_rssi_compute_hook);
+
+__attribute__((naked))
+void
+exit_wlc_recv_18_41_117_sta(uint32_t monitor)
+{
+    asm(
+        "cmp r0, #2\n"              // path_to_path_to_indirect_call_of_phy_ac_rssi_compute_hook return value of wlc->monitor in r0
+        "beq 0x239B02\n"            // if wlc->monitor == 2 then quit wlc_recv without further processing p
+        "ldrb r2, [r6,#0xE]\n"      // overwritten instruction
+        "lsls r1, r2, #0x1F\n"      // overwritten instruction
+        "b 0x239998\n"              // branch to address after overwritten instructions
+    );
+}
+
+__attribute__((at(0x239994, "", CHIP_VER_BCM4375b1, FW_VER_18_41_117_sta)))
+BPatch(exit_wlc_recv_18_41_117_sta, exit_wlc_recv_18_41_117_sta);
+
+//__attribute__((at(0x231EB0, "", CHIP_VER_BCM4375b1, FW_VER_18_41_8_9_sta)))
+//BPatch(exit_wlc_recv_18_41_8_9_sta, exit_wlc_recv_18_41_8_9_sta);
+
+//__attribute__((at(0x2170E0, "", CHIP_VER_BCM4375b1, FW_VER_18_38_18_sta)))
+//BPatch(exit_wlc_recv_18_38_18_sta, exit_wlc_recv_18_38_18_sta);
+
+__attribute__((at(0x26CC7E, "", CHIP_VER_BCM4375b1, FW_VER_18_41_117_sta)))
+__attribute__((at(0x265502, "", CHIP_VER_BCM4375b1, FW_VER_18_41_8_9_sta)))
+__attribute__((at(0x24983E, "", CHIP_VER_BCM4375b1, FW_VER_18_38_18_sta)))
+BLPatch(wlc_okc_attach_hook, wlc_okc_attach_hook);

--- a/patches/bcm4375b1/18_41_117_sta/nexmon/src/patch.c
+++ b/patches/bcm4375b1/18_41_117_sta/nexmon/src/patch.c
@@ -1,0 +1,109 @@
+/***************************************************************************
+ *                                                                         *
+ *          ###########   ###########   ##########    ##########           *
+ *         ############  ############  ############  ############          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ###########   ####  ######  ##   ##   ##  ##    ######          *
+ *          ###########  ####  #       ##   ##   ##  ##    #    #          *
+ *                   ##  ##    ######  ##   ##   ##  ##    #    #          *
+ *                   ##  ##    #       ##   ##   ##  ##    #    #          *
+ *         ############  ##### ######  ##   ##   ##  ##### ######          *
+ *         ###########    ###########  ##   ##   ##   ##########           *
+ *                                                                         *
+ *            S E C U R E   M O B I L E   N E T W O R K I N G              *
+ *                                                                         *
+ * This file is part of NexMon.                                            *
+ *                                                                         *
+ * Copyright (c) 2016 NexMon Team                                          *
+ *                                                                         *
+ * NexMon is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by    *
+ * the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                     *
+ *                                                                         *
+ * NexMon is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of          *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
+ * GNU General Public License for more details.                            *
+ *                                                                         *
+ * You should have received a copy of the GNU General Public License       *
+ * along with NexMon. If not, see <http://www.gnu.org/licenses/>.          *
+ *                                                                         *
+ **************************************************************************/
+
+#pragma NEXMON targetregion "patch"
+
+#include <firmware_version.h>
+#include <wrapper.h>	// wrapper definitions for functions that already exist in the firmware
+#include <structs.h>	// structures that are used by the code in the firmware
+#include <patcher.h>
+#include <helper.h>
+#include <capabilities.h>      // capabilities included in a nexmon patch
+
+extern unsigned char ucode1_compressed_bin[];
+extern unsigned int ucode1_compressed_bin_len;
+extern unsigned char ucode2_compressed_bin[];
+extern unsigned int ucode2_compressed_bin_len;
+
+int capabilities = 0;
+
+// Hook the call to wlc_ucode_write in wlc_ucode_download
+__attribute__((at(WLC_UCODE_WRITE_BL_HOOK_ADDR, "", CHIP_VER_ALL, FW_VER_ALL)))
+BLPatch(wlc_ucode_write_compressed, wlc_ucode_write_compressed_args);
+
+__attribute__((at(UCODE1START_PTR, "", CHIP_VER_ALL, FW_VER_ALL)))
+GenericPatch4(ucode1start_ptr, ucode1_compressed_bin);
+
+__attribute__((at(UCODE1SIZE_PTR, "", CHIP_VER_ALL, FW_VER_ALL)))
+GenericPatch4(ucode1size_ptr, &ucode1_compressed_bin_len);
+
+__attribute__((at(UCODE2START_PTR, "", CHIP_VER_ALL, FW_VER_ALL)))
+GenericPatch4(ucode2start_ptr, ucode2_compressed_bin);
+
+__attribute__((at(UCODE2SIZE_PTR, "", CHIP_VER_ALL, FW_VER_ALL)))
+GenericPatch4(ucode2size_ptr, &ucode2_compressed_bin_len);
+
+__attribute__((at(HNDRTE_RECLAIM_0_END_PTR, "", CHIP_VER_ALL, FW_VER_ALL)))
+GenericPatch4(hndrte_reclaim_0_end, PATCHSTART);
+
+// Moving template ram to another place in the ucode region
+#if TEMPLATERAMSTART0_PTR != 0
+extern unsigned char templateram0_bin[];
+
+__attribute__((at(TEMPLATERAMSTART0_PTR, "", CHIP_VER_ALL, FW_VER_ALL)))
+GenericPatch4(templateram0_bin, templateram0_bin);
+#endif
+
+#if TEMPLATERAMSTART1_PTR != 0
+extern unsigned char templateram1_bin[];
+
+__attribute__((at(TEMPLATERAMSTART1_PTR, "", CHIP_VER_ALL, FW_VER_ALL)))
+GenericPatch4(templateram1_bin, templateram1_bin);
+#endif
+
+#if TEMPLATERAMSTART2_PTR != 0
+extern unsigned char templateram2_bin[];
+
+__attribute__((at(TEMPLATERAMSTART2_PTR, "", CHIP_VER_ALL, FW_VER_ALL)))
+GenericPatch4(templateram2_bin, templateram2_bin);
+#endif
+
+// Moving vasip firmware to another place in the ucode region
+#if VASIPSTART_PTR != 0
+extern unsigned char vasip_bin[];
+
+__attribute__((at(VASIPSTART_PTR, "", CHIP_VER_ALL, FW_VER_ALL)))
+GenericPatch4(vasip_bin, vasip_bin);
+#endif
+
+// Deactivate the no execution bit (XN) for data area to allow to place firmware patches there
+__attribute__((at(0x1D4D8C, "", CHIP_VER_BCM4375b1, FW_VER_18_41_117_sta)))
+__attribute__((at(0x1D2B30, "", CHIP_VER_BCM4375b1, FW_VER_18_41_8_9_sta)))
+__attribute__((at(0x1c55b8, "", CHIP_VER_ALL, FW_VER_18_38_18_sta)))
+__attribute__((naked))
+void
+xn_patch(void)
+{
+	asm("bic r2, r2, 0x1000\n");
+}

--- a/patches/bcm4375b1/18_41_117_sta/nexmon/src/version.c
+++ b/patches/bcm4375b1/18_41_117_sta/nexmon/src/version.c
@@ -1,0 +1,42 @@
+/***************************************************************************
+ *                                                                         *
+ *          ###########   ###########   ##########    ##########           *
+ *         ############  ############  ############  ############          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ###########   ####  ######  ##   ##   ##  ##    ######          *
+ *          ###########  ####  #       ##   ##   ##  ##    #    #          *
+ *                   ##  ##    ######  ##   ##   ##  ##    #    #          *
+ *                   ##  ##    #       ##   ##   ##  ##    #    #          *
+ *         ############  ##### ######  ##   ##   ##  ##### ######          *
+ *         ###########    ###########  ##   ##   ##   ##########           *
+ *                                                                         *
+ *            S E C U R E   M O B I L E   N E T W O R K I N G              *
+ *                                                                         *
+ * This file is part of NexMon.                                            *
+ *                                                                         *
+ * Copyright (c) 2016 NexMon Team                                          *
+ *                                                                         *
+ * NexMon is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by    *
+ * the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                     *
+ *                                                                         *
+ * NexMon is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of          *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
+ * GNU General Public License for more details.                            *
+ *                                                                         *
+ * You should have received a copy of the GNU General Public License       *
+ * along with NexMon. If not, see <http://www.gnu.org/licenses/>.          *
+ *                                                                         *
+ **************************************************************************/
+
+#pragma NEXMON targetregion "patch"
+
+#include <firmware_version.h>   // definition of firmware version macros
+#include <patcher.h>            // macros used to craete patches such as BLPatch, BPatch, ...
+
+char version[] = "18.41.117 (nexmon.org: " GIT_VERSION "-" BUILD_NUMBER ")";
+char date[] = __DATE__;
+char time[] = __TIME__;

--- a/patches/bcm4375b1/18_41_117_sta/version.mk
+++ b/patches/bcm4375b1/18_41_117_sta/version.mk
@@ -1,0 +1,1 @@
+FW_PATH=$(NEXMON_ROOT)/firmwares/bcm4375b1/18_41_117_sta


### PR DESCRIPTION
Adds the firmware patch for bcm4375b1 for the version 18.41.117.

Its based on the 18.41.8.9 patch.