### PR TITLE
bcm43439a0: add 802.11 frame injection support

### DIFF
--- a/firmwares/bcm43439a0/structs.common.h
+++ b/firmwares/bcm43439a0/structs.common.h
@@ -65,10 +65,18 @@ struct sk_buff {
         };
         void *freelist;
     };
-    uint32      pkttag[8];          /* 0x018 */
+    uint32      pkttag[4];          /* 0x018 */
+    void       *scb;                /* 0x028 packet scb; wlc_txfifo and wlc_d11hdrs both deref it at +16 via [p+0x28] */
+    uint32      pkttag2[3];         /* 0x02c */
 } __attribute__((packed));
 typedef struct sk_buff sk_buff;
 typedef struct sk_buff lbuf;
+
+/* TX-header scratch filled by wlc_get_txh_info(); opaque 80-byte blob.
+ * Ported verbatim from firmwares/bcm43430a1/structs.common.h. */
+struct wlc_txh_info {
+    uint8 PAD[80];
+} __attribute__((packed));
 
 struct osl_info {
     uint32 PAD;                       /* 0x000 */
@@ -883,9 +891,29 @@ struct wlc_hwband {
     uint16 PAD;                       /* 0x02a */
 } __attribute((packed));
 
+/* Software band (wlc->band).  The classic injection sendframe() reads its
+ * hwrs_scb (hardware rate-set scb) as the TX scb for injected frames.  Modeled
+ * on the sibling firmwares/bcm43430a1/structs.common.h "struct wlcband".
+ * Distinct from the existing "struct wlc_hwband" (the hardware band in wlc_hw). */
+struct wlc_band {
+    uint32 bandtype;                  /* 0x000 */
+    uint32 bandunit;                  /* 0x004 */
+    uint16 phytype;                   /* 0x008 */
+    uint16 phyrev;                    /* 0x00a */
+    uint16 radioid;                   /* 0x00c */
+    uint16 radiorev;                  /* 0x00e */
+    struct phy_info *pi;              /* 0x010 */
+    uint8  abgphy_encore;             /* 0x014 */
+    uint8  gmode;                     /* 0x015 */
+    uint16 PAD;                       /* 0x016 */
+    struct scb *hwrs_scb;             /* 0x018 hardware rate-set scb; ROM 0x82e7c8 default-scb routine derives it as band+0x18, then scb+16 */
+} __attribute__((packed));
+
 struct wlc_hw_info {
     struct wlc_info *wlc;             /* 0x000 */
-    uint32 PAD;                       /* 0x004 */
+    uint16 PAD;                       /* 0x004 */
+    uint8  up;                        /* 0x006 MAC-up flag; the dominant wlc->hw boolean gate in the ROM/RAM dump (23 sites) */
+    uint8  PAD;                       /* 0x007 */
     void *osh;                        /* 0x008 */
     uint32 unit;                      /* 0x00c */
     uint32 PAD;                       /* 0x010 */
@@ -1028,7 +1056,7 @@ struct wlc_info {
     uint32 PAD;                       /* 0x014 */
     uint32 PAD;                       /* 0x018 */
     void *core;                       /* 0x01c */
-    void *band;                       /* 0x020 */
+    struct wlc_band *band;            /* 0x020 */  /* retyped from void*; field offset unchanged */
     void *corestate;                  /* 0x024 */
     void *bandstate[2];               /* 0x028 */
 //    uint32 PAD;                       /* 0x02c */

--- a/patches/bcm43439a0/7_95_49_2271bb6/nexmon/src/injection.c
+++ b/patches/bcm43439a0/7_95_49_2271bb6/nexmon/src/injection.c
@@ -1,0 +1,121 @@
+/***************************************************************************
+ *                                                                         *
+ *          ###########   ###########   ##########    ##########           *
+ *         ############  ############  ############  ############          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ##            ##            ##   ##   ##  ##        ##          *
+ *         ###########   ####  ######  ##   ##   ##  ##    ######          *
+ *          ###########  ####  #       ##   ##   ##  ##    #    #          *
+ *                   ##  ##    ######  ##   ##   ##  ##    #    #          *
+ *                   ##  ##    #       ##   ##   ##  ##    #    #          *
+ *         ############  ##### ######  ##   ##   ##  ##### ######          *
+ *         ###########    ###########  ##   ##   ##   ##########           *
+ *                                                                         *
+ *            S E C U R E   M O B I L E   N E T W O R K I N G              *
+ *                                                                         *
+ * This file is part of NexMon.                                            *
+ *                                                                         *
+ * Copyright (c) 2023 NexMon Team                                          *
+ *                                                                         *
+ * NexMon is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by    *
+ * the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                     *
+ *                                                                         *
+ * NexMon is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of          *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
+ * GNU General Public License for more details.                            *
+ *                                                                         *
+ * You should have received a copy of the GNU General Public License       *
+ * along with NexMon. If not, see <http://www.gnu.org/licenses/>.          *
+ *                                                                         *
+ **************************************************************************/
+
+/*
+ * Frame injection entry point for bcm43439a0.
+ * Ported from patches/bcm43430a1/7_45_41_46/nexmon/src/injection.c.
+ *
+ * IMPORTANT divergence from the classic port:
+ * the Pico W has no Linux netdev and no mon0 interface, so there is NO
+ * wl_send_hook / netdev-transmit GenericPatch4 here.  inject_frame() is driven
+ * purely by the NEX_INJECT_FRAME ioctl case in ioctl.c, which hands us a fully
+ * formed, radiotap-prefixed skb.  We therefore take (wlc, p) directly instead
+ * of (wl, p): the ioctl hook already has wlc in hand.
+ *
+ * Do NOT include local_wrapper.h here: the 43439 ships include/local_wrapper.h
+ * but no src/local_wrapper.c, so any file that includes it fails to build.
+ */
+
+#pragma NEXMON targetregion "patch"
+
+#include <firmware_version.h>   // definition of firmware version macros
+#include <wrapper.h>            // wrapper definitions for functions that already exist in the firmware
+#include <structs.h>            // structures that are used by the code in the firmware
+#include <patcher.h>            // macros used to create patches such as BLPatch, BPatch, ...
+#include <helper.h>             // useful helper functions
+#include <ieee80211_radiotap.h> // radiotap header parsing
+#include <sendframe.h>          // sendframe()
+#include "d11.h"
+#include "brcm.h"
+
+int
+inject_frame(struct wlc_info *wlc, struct sk_buff *p)
+{
+    int rtap_len = 0;
+    int data_rate = 0;
+
+    struct ieee80211_radiotap_iterator iterator;
+    struct ieee80211_radiotap_header *rtap_header;
+
+    // radiotap it_len is a little-endian uint16 at offset 2 (bytes 2..3). Read
+    // both bytes so we agree with the iterator; a single signed byte would
+    // sign-extend and disagree for lengths > 127.
+    rtap_len = ((unsigned char *)p->data)[2] | (((unsigned char *)p->data)[3] << 8);
+    rtap_header = (struct ieee80211_radiotap_header *) p->data;
+
+    // The NEX_INJECT_FRAME caller controls these header bytes. Never trust it_len
+    // past the actual frame: an overstated it_len would let the iterator read
+    // past the skb allocation and would underflow p->len (uint16) at skb_pull below.
+    if (rtap_len < sizeof(struct ieee80211_radiotap_header) || rtap_len > p->len) {
+        printf("ERR: inject rtap_len\n");
+        pkt_buf_free_skb(wlc->osh, p, 0);
+        return -1;
+    }
+
+    // Bound the iterator by the real frame length so it can never be told the
+    // buffer is larger than it is.
+    int ret = ieee80211_radiotap_iterator_init(&iterator, rtap_header, p->len, 0);
+
+    if (ret) {
+        // malformed radiotap header: free the skb so the ioctl path never leaks it
+        printf("ERR: inject rtap_init\n");
+        pkt_buf_free_skb(wlc->osh, p, 0);
+        return -1;
+    }
+
+    while (!ret) {
+        ret = ieee80211_radiotap_iterator_next(&iterator);
+        if (ret) {
+            continue;
+        }
+        switch (iterator.this_arg_index) {
+            case IEEE80211_RADIOTAP_RATE:
+                // legacy rate, in 500 kbps units, used as the rspec override
+                data_rate = (*iterator.this_arg);
+                break;
+            case IEEE80211_RADIOTAP_CHANNEL:
+                break;
+            default:
+                break;
+        }
+    }
+
+    skb_pull(p, rtap_len);
+
+    // inject straight into TX FIFO 1, bypassing the regular tx queue.
+    // sendframe() consumes p (hands it to the DMA FIFO) or frees it on error.
+    sendframe(wlc, p, 1, data_rate);
+
+    return 0;
+}

--- a/patches/bcm43439a0/7_95_49_2271bb6/nexmon/src/patch.c
+++ b/patches/bcm43439a0/7_95_49_2271bb6/nexmon/src/patch.c
@@ -38,7 +38,10 @@
 #include <patcher.h>
 #include <capabilities.h>      // capabilities included in a nexmon patch
 
-int capabilities = 0;
+// Advertise monitor + radiotap (already implemented in monitormode.c) and the
+// frame injection added by injection.c / sendframe.c / the NEX_INJECT_FRAME
+// ioctl case.  Reported back to the host via NEX_GET_CAPABILITIES.
+int capabilities = NEX_CAP_MONITOR_MODE | NEX_CAP_MONITOR_MODE_RADIOTAP | NEX_CAP_FRAME_INJECTION;
 
 // Hook the call to wlc_ucode_write in wlc_ucode_download
 __attribute__((at(WLC_UCODE_WRITE_BL_HOOK_ADDR, "", CHIP_VER_BCM43439a0, FW_VER_7_95_49_2271bb6)))

--- a/patches/bcm43439a0/7_95_49_2271bb6/nexmon/src/sendframe.c
+++ b/patches/bcm43439a0/7_95_49_2271bb6/nexmon/src/sendframe.c
@@ -32,78 +32,58 @@
  *                                                                         *
  **************************************************************************/
 
+/*
+ * Classic (bcm43430a1) frame-injection TX path, ported to bcm43439a0.
+ * Ported from patches/bcm43430a1/7_45_41_46/nexmon/src/sendframe.c.
+ *
+ * Symbols used here are all already resolved for the 43439 in
+ * patches/common/wrapper.c:
+ *   wlc_d11hdrs       @ 0x8929FC   build the d11 TX descriptor
+ *   wlc_get_txh_info  @ 0x82B8FC   read the tx header info into a scratch blob
+ *   wlc_txfifo        @ 0x834194   enqueue into TX DMA FIFO 1
+ *   pkt_buf_free_skb  @ 0x80C144   free on the error path
+ *
+ * The two struct fields touched here (wlc->band->hwrs_scb at band+0x018 and
+ * wlc->hw->up at hw+0x006) were resolved against the 43439 ROM/RAM dump; see
+ * structs.common.h.
+ */
+
 #pragma NEXMON targetregion "patch"
 
 #include <firmware_version.h>   // definition of firmware version macros
+#include <debug.h>              // contains macros to access the debug hardware
 #include <wrapper.h>            // wrapper definitions for functions that already exist in the firmware
 #include <structs.h>            // structures that are used by the code in the firmware
 #include <helper.h>             // useful helper functions
 #include <patcher.h>            // macros used to create patches such as BLPatch, BPatch, ...
+#include <rates.h>              // rates used to build the ratespec for frame injection
 #include <nexioctls.h>          // ioctls added in the nexmon patch
 #include <capabilities.h>       // capabilities included in a nexmon patch
-#include <sendframe.h>          // sendframe functionality
-#include <argprintf.h>
 
-// Defined in injection.c.  Parses the radiotap header off an skb and hands the
-// bare 802.11 frame to sendframe(); consumes (tx) or frees the skb on error.
-int inject_frame(struct wlc_info *wlc, struct sk_buff *p);
-
-// Headroom reserved in front of the injected frame so wlc_d11hdrs() can prepend
-// the d11 TX header (PLCP + d11txh) without reallocating.  Borrowed from the
-// bcm43455 ioctl-driven injection path.  The 43439 d11 tx header tops out near
-// 0xb0 bytes (per wlc_get_txh_info), so 202 over-reserves it.
-#define INJECT_HEADROOM 202
-
-int
-wlc_ioctl_hook(struct wlc_info *wlc, int cmd, char *arg, int len, void *wlc_if)
+void
+sendframe(struct wlc_info *wlc, struct sk_buff *p, unsigned int fifo, unsigned int rate)
 {
-    argprintf_init(arg, len);
-    int ret = IOCTL_ERROR;
+    int short_preamble = 0;
+    struct wlc_txh_info txh = {0};
 
-    switch (cmd) {
-        case NEX_GET_CAPABILITIES:
-            if (len == 4) {
-                memcpy(arg, &capabilities, 4);
-                ret = IOCTL_SUCCESS;
-            }
-            break;
-
-        case NEX_WRITE_TO_CONSOLE:
-            if (len > 0) {
-                arg[len-1] = 0;
-                printf("ioctl: %s\n", arg);
-                ret = IOCTL_SUCCESS;
-            }
-            break;
-
-        case NEX_INJECT_FRAME:
-            // arg is a single radiotap-prefixed 802.11 frame of length len,
-            // fired by the host with cyw43_ioctl(IOCTL_CMD_SET(408), len, frame, ...)
-            if (len > 0) {
-                struct sk_buff *p = pkt_buf_get_skb(wlc->osh, len + INJECT_HEADROOM);
-
-                if (p != 0) {
-                    skb_pull(p, INJECT_HEADROOM);
-                    memcpy(p->data, arg, len);
-                    // Do not report success for a frame we never queued: a
-                    // malformed radiotap header makes inject_frame return -1
-                    // (and free the skb). The host must not read ret==0 as
-                    // "transmitted". Note the wlc-down / no-scb drops still
-                    // return 0 via the void sendframe; the over-the-air witness,
-                    // not this ret, is the proof of transmission.
-                    ret = inject_frame(wlc, p) == 0 ? IOCTL_SUCCESS : IOCTL_ERROR;
-                } else {
-                    ret = IOCTL_ERROR;
-                }
-            }
-            break;
-
-        default:
-            ret = wlc_ioctl(wlc, cmd, arg, len, wlc_if);
+    // hwrs_scb is the hardware-rate-set scb the firmware uses as the TX scb for
+    // self-originated frames; hw->up gates TX on the MAC being up.  Both offsets
+    // are from the ROM/RAM dump (see structs.common.h).
+    if (wlc->band->hwrs_scb) {
+        if (wlc->hw->up) {
+            wlc_d11hdrs(wlc, p, wlc->band->hwrs_scb, short_preamble, 0, 1, 1, 0, 0, rate);
+            p->scb = wlc->band->hwrs_scb;
+            wlc_get_txh_info(wlc, p, &txh);
+            wlc_txfifo(wlc, fifo, p, &txh, 1, 1);
+        } else {
+            // MAC is down: nothing will transmit. Free the skb instead of
+            // leaking it; the ioctl trigger fires at 1 Hz, so a leak here
+            // exhausts the packet pool and wedges the chip.
+            printf("ERR: wlc down\n");
+            pkt_buf_free_skb(wlc->osh, p, 0);
+        }
+    } else {
+        printf("ERR: no scb found, discarding packet!\n");
+        pkt_buf_free_skb(wlc->osh, p, 0);
     }
-
-    return ret;
 }
-
-__attribute__((at(0x1EFC4, "", CHIP_VER_BCM43439a0, FW_VER_7_95_49_2271bb6)))
-GenericPatch4(wlc_ioctl_hook, wlc_ioctl_hook + 1);


### PR DESCRIPTION
### Summary

Adds 802.11 frame injection (TX) for the Raspberry Pi Pico W (Infineon CYW43439, `bcm43439a0`), firmware 7.95.49 (`7_95_49_2271bb6`).

Monitor mode and radiotap for this chip were merged in #579. Frame injection was the remaining gap in the support table (`M:X RT:X I:` blank) and is the feature requested in #687. `NEX_GET_CAPABILITIES` now returns `0x7` (monitor | radiotap | injection).

### Approach

The Pico W runs the WLAN firmware over gSPI with no Linux netdev and no `mon0` interface, so the classic injection trigger (hijacking the netdev transmit path and watching `mon0` for radiotap frames) does not exist here. Injection is driven instead by a new `NEX_INJECT_FRAME` (408) case added to the existing `wlc_ioctl_hook` (`GenericPatch4 @ 0x1EFC4`). The host sends a single radiotap-prefixed 802.11 frame per ioctl; the patch parses and strips the radiotap header, then hands the bare frame to the classic `sendframe()` TX path (`wlc_d11hdrs` -> `wlc_get_txh_info` -> `wlc_txfifo`).

### Changes

* `patches/bcm43439a0/7_95_49_2271bb6/nexmon/src/sendframe.c` (new): classic TX path, ported from `bcm43430a1`.
* `.../src/injection.c` (new): radiotap parse plus `inject_frame(wlc, p)`. Takes `wlc` directly because the ioctl hook already holds it, rather than deriving it from a `wl_info`.
* `.../src/ioctl.c`: the `NEX_INJECT_FRAME` case. It reserves headroom before the copy so `wlc_d11hdrs` can prepend the d11 TX header without reallocating, and it does not report `IOCTL_SUCCESS` for a frame that failed radiotap parsing.
* `.../src/patch.c`: `capabilities = NEX_CAP_MONITOR_MODE | NEX_CAP_MONITOR_MODE_RADIOTAP | NEX_CAP_FRAME_INJECTION`.
* `firmwares/bcm43439a0/structs.common.h`: the three struct fields `sendframe()` needs, plus the software `wlc_band` and the opaque `wlc_txh_info` scratch type.

All required firmware symbols (`wlc_d11hdrs`, `wlc_get_txh_info`, `wlc_txfifo`, `pkt_buf_*`, `wlc_ioctl`) are already resolved for `CHIP_VER_BCM43439a0` in `patches/common/wrapper.c`, and `NEX_INJECT_FRAME` and `NEX_CAP_FRAME_INJECTION` already exist in the common headers, so no common-header or Makefile changes were needed.

### Struct offsets

`sendframe()` reads three fields the 43439 header did not describe. Each was resolved against a real bcm43439a0 ROM/RAM dump. The firmware dispatches these `wlc_*` functions through a ROM patch-table thunk into the loaded RAM blob, so the struct-access idioms were read from the RAM image and cross-checked against the ROM.

| Field | Offset | Evidence |
|---|---|---|
| `wlc_band.hwrs_scb` | `0x018` | the firmware default-scb routine at ROM `0x82e7c8`: `wlc+0x20` is band, `band+0x18` loads the scb, then `scb+16` is dereferenced. |
| `wlc_hw_info.up` | `0x006` | the dominant `wlc->hw` boolean gate (23 sites, base verified as `wlc`). The originally seeded 0x0a0 has zero gate sites. |
| `sk_buff.scb` | `0x028` | `wlc_txfifo` reads the packet scb from `[p+0x28]`, and `wlc_d11hdrs` does not write it, so the `p->scb =` assignment is required rather than redundant. |

### Verification

Built with the nexmon toolchain; the patched firmware links within the reclaim region. Confirmed over the air with an independent monitor-mode witness on channel 6: the injected beacon is received with the expected test SSID, source/BSSID `02:13:37:de:ad:01`, and broadcast destination `ff:ff:ff:ff:ff:ff`.

### Notes

* Injection is ioctl-driven and does not gate on `wlc->monitor`; the host is responsible for setting the channel first (and monitor mode too if it also wants RX). `sendframe()` still self-guards on `hwrs_scb` and `hw->up`.
* `monitormode.c` is unchanged. Its `MONITOR_*` enum drift from the canonical bitflag scheme is noted in-tree but injection does not depend on it.
